### PR TITLE
Add grid overlay on slice plane viewer

### DIFF
--- a/viz/src/components/builder/Preview3D.tsx
+++ b/viz/src/components/builder/Preview3D.tsx
@@ -10,6 +10,7 @@ import { MaterialRegion } from './MaterialRegion'
 import { SourceMarker } from './SourceMarker'
 import { ProbeMarker } from './ProbeMarker'
 import { SlicePlane } from './SlicePlane'
+import { SlicePlaneGrid } from './SlicePlaneGrid'
 import { MeasurementLine } from './MeasurementLine'
 import { useBuilderStore, type MeasurementPoint } from '@/stores/builderStore'
 import type { SimulationAST } from '@/lib/scriptParser'
@@ -27,6 +28,7 @@ interface Preview3DProps {
   dualSliceMode: boolean
   slice1Position: number
   slice2Position: number
+  showSliceGrid: boolean
 }
 
 function Scene({
@@ -42,6 +44,7 @@ function Scene({
   dualSliceMode,
   slice1Position,
   slice2Position,
+  showSliceGrid,
 }: Preview3DProps) {
   const addMeasurementPoint = useBuilderStore((s) => s.addMeasurementPoint)
 
@@ -105,15 +108,35 @@ function Scene({
             measurementMode={measurementMode}
             color="#4a90e2"
           />
-          {dualSliceMode && (
-            <SlicePlane
+          {showSliceGrid && (
+            <SlicePlaneGrid
               axis={sliceAxis}
-              position={slice2Position}
+              position={dualSliceMode ? slice1Position : slicePosition}
               extent={grid.extent}
-              onClick={handleSliceClick}
-              measurementMode={measurementMode}
-              color="#e24a90"
+              color="#4a90e2"
+              opacity={0.4}
             />
+          )}
+          {dualSliceMode && (
+            <>
+              <SlicePlane
+                axis={sliceAxis}
+                position={slice2Position}
+                extent={grid.extent}
+                onClick={handleSliceClick}
+                measurementMode={measurementMode}
+                color="#e24a90"
+              />
+              {showSliceGrid && (
+                <SlicePlaneGrid
+                  axis={sliceAxis}
+                  position={slice2Position}
+                  extent={grid.extent}
+                  color="#e24a90"
+                  opacity={0.4}
+                />
+              )}
+            </>
           )}
         </>
       )}

--- a/viz/src/components/builder/SlicePlaneGrid.tsx
+++ b/viz/src/components/builder/SlicePlaneGrid.tsx
@@ -1,0 +1,108 @@
+/**
+ * Grid overlay for slice planes - provides visual reference for spatial reasoning
+ */
+
+import { useMemo } from 'react'
+import * as THREE from 'three'
+
+interface SlicePlaneGridProps {
+  axis: 'xy' | 'xz' | 'yz'
+  position: number  // 0-1 range
+  extent: [number, number, number]
+  gridSpacing?: number  // Grid cell size in meters
+  color?: string
+  opacity?: number
+}
+
+export function SlicePlaneGrid({
+  axis,
+  position,
+  extent,
+  gridSpacing,
+  color = '#666666',
+  opacity = 0.5,
+}: SlicePlaneGridProps) {
+  const geometry = useMemo(() => {
+    // Determine plane dimensions and position based on axis
+    let size1: number, size2: number
+    let planePosition: [number, number, number]
+
+    switch (axis) {
+      case 'xy':
+        size1 = extent[0]
+        size2 = extent[1]
+        planePosition = [extent[0] / 2, extent[1] / 2, extent[2] * position]
+        break
+      case 'xz':
+        size1 = extent[0]
+        size2 = extent[2]
+        planePosition = [extent[0] / 2, extent[1] * position, extent[2] / 2]
+        break
+      case 'yz':
+        size1 = extent[1]
+        size2 = extent[2]
+        planePosition = [extent[0] * position, extent[1] / 2, extent[2] / 2]
+        break
+    }
+
+    // Calculate adaptive grid spacing based on plane size (target ~20-40 divisions)
+    const maxDim = Math.max(size1, size2)
+    const defaultSpacing = gridSpacing ?? maxDim / 20
+
+    const divisions1 = Math.ceil(size1 / defaultSpacing)
+    const divisions2 = Math.ceil(size2 / defaultSpacing)
+    const actualSpacing1 = size1 / divisions1
+    const actualSpacing2 = size2 / divisions2
+
+    // Generate grid line vertices
+    const points: number[] = []
+
+    // Lines along first axis
+    for (let i = 0; i <= divisions1; i++) {
+      const t = i * actualSpacing1 - size1 / 2
+      points.push(t, -size2 / 2, 0)
+      points.push(t, size2 / 2, 0)
+    }
+
+    // Lines along second axis
+    for (let j = 0; j <= divisions2; j++) {
+      const t = j * actualSpacing2 - size2 / 2
+      points.push(-size1 / 2, t, 0)
+      points.push(size1 / 2, t, 0)
+    }
+
+    const geom = new THREE.BufferGeometry()
+    geom.setAttribute('position', new THREE.Float32BufferAttribute(points, 3))
+
+    return { geometry: geom, planePosition }
+  }, [axis, position, extent, gridSpacing])
+
+  // Calculate rotation to align grid with slice plane
+  const rotation = useMemo((): [number, number, number] => {
+    switch (axis) {
+      case 'xy':
+        return [0, 0, 0]
+      case 'xz':
+        return [Math.PI / 2, 0, 0]
+      case 'yz':
+        return [0, 0, Math.PI / 2]
+    }
+  }, [axis])
+
+  return (
+    <lineSegments
+      position={geometry.planePosition}
+      rotation={rotation}
+      geometry={geometry.geometry}
+      renderOrder={1}
+    >
+      <lineBasicMaterial
+        color={color}
+        opacity={opacity}
+        transparent
+        depthTest={true}
+        depthWrite={false}
+      />
+    </lineSegments>
+  )
+}

--- a/viz/src/pages/SimulationBuilder.tsx
+++ b/viz/src/pages/SimulationBuilder.tsx
@@ -2,7 +2,7 @@
  * Simulation Builder page - Script editor with live 3D preview
  */
 
-import { ArrowLeft, HelpCircle, Eye, EyeOff, Ruler, Layers } from 'lucide-react'
+import { ArrowLeft, HelpCircle, Eye, EyeOff, Ruler, Layers, Grid3x3 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Slider } from '@/components/ui/slider'
@@ -195,6 +195,17 @@ export function SimulationBuilder({ onBack }: SimulationBuilderProps) {
                     Dual Slice
                   </Button>
 
+                  {/* Slice grid toggle */}
+                  <Button
+                    variant={viewOptions.showSliceGrid ? 'default' : 'outline'}
+                    size="sm"
+                    onClick={() => toggleViewOption('showSliceGrid')}
+                    className="gap-1.5 text-xs h-7"
+                  >
+                    <Grid3x3 className="h-3 w-3" />
+                    Slice Grid
+                  </Button>
+
                   {viewOptions.dualSliceMode ? (
                     <>
                       {/* Slice 1 position */}
@@ -273,6 +284,7 @@ export function SimulationBuilder({ onBack }: SimulationBuilderProps) {
               dualSliceMode={viewOptions.dualSliceMode}
               slice1Position={viewOptions.slice1Position}
               slice2Position={viewOptions.slice2Position}
+              showSliceGrid={viewOptions.showSliceGrid}
             />
           </div>
 

--- a/viz/src/stores/builderStore.ts
+++ b/viz/src/stores/builderStore.ts
@@ -18,6 +18,7 @@ interface ViewOptions {
   dualSliceMode: boolean
   slice1Position: number
   slice2Position: number
+  showSliceGrid: boolean
 }
 
 export interface MeasurementPoint {
@@ -114,6 +115,7 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
     dualSliceMode: false,
     slice1Position: 0.33,
     slice2Position: 0.67,
+    showSliceGrid: false,
   },
 
   measurementPoints: [],
@@ -157,9 +159,10 @@ export const useBuilderStore = create<BuilderState>((set, get) => ({
       viewOptions: {
         ...state.viewOptions,
         sliceAxis: axis,
-        // Disable measurement mode and dual slice mode when disabling slice
+        // Disable measurement mode, dual slice mode, and slice grid when disabling slice
         measurementMode: axis === 'none' ? false : state.viewOptions.measurementMode,
         dualSliceMode: axis === 'none' ? false : state.viewOptions.dualSliceMode,
+        showSliceGrid: axis === 'none' ? false : state.viewOptions.showSliceGrid,
       },
       // Clear measurements when switching slice axis
       measurementPoints: [],


### PR DESCRIPTION
## Summary

Adds an optional 2D grid overlay on slice planes to provide visual reference for spatial reasoning and distance estimation.

- Add SlicePlaneGrid component with adaptive grid spacing (~20 divisions)
- Add "Slice Grid" toggle button in slice plane controls
- Grid color matches slice plane color (blue for primary, pink for secondary in dual mode)
- Grid automatically disabled when slice axis is set to 'none'

## Changes

- `viz/src/components/builder/SlicePlaneGrid.tsx` - New component for grid overlay
- `viz/src/stores/builderStore.ts` - Add `showSliceGrid` to ViewOptions
- `viz/src/pages/SimulationBuilder.tsx` - Add Slice Grid toggle button
- `viz/src/components/builder/Preview3D.tsx` - Integrate grid rendering

## Test Plan

- [ ] Toggle slice axis to XY/XZ/YZ - verify grid appears when enabled
- [ ] Toggle "Slice Grid" button on/off - verify grid visibility changes
- [ ] Move slice position slider - verify grid follows slice plane
- [ ] Enable dual slice mode - verify both slices can have grids
- [ ] Set slice axis to "None" - verify grid toggle is hidden and grid disappears

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)