### PR TITLE
Add click-to-jump navigation in Builder Mode error panel

### DIFF
--- a/viz/src/components/builder/ErrorPanel.tsx
+++ b/viz/src/components/builder/ErrorPanel.tsx
@@ -8,9 +8,10 @@ import type { ValidationError } from '../../lib/pythonValidator'
 interface ErrorPanelProps {
   errors: ValidationError[]
   onClose?: () => void
+  onErrorClick?: (line: number, column: number) => void
 }
 
-export function ErrorPanel({ errors, onClose }: ErrorPanelProps) {
+export function ErrorPanel({ errors, onClose, onErrorClick }: ErrorPanelProps) {
   if (errors.length === 0) {
     return null
   }
@@ -55,11 +56,20 @@ export function ErrorPanel({ errors, onClose }: ErrorPanelProps) {
         {errors.map((error, index) => (
           <div
             key={index}
+            onClick={() => onErrorClick?.(error.line, error.column)}
             className={`
               flex items-start gap-3 border-b border-gray-700 px-4 py-3
               hover:bg-gray-800 transition-colors cursor-pointer
               ${error.severity === 'error' ? 'bg-red-950/20' : 'bg-yellow-950/20'}
             `}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault()
+                onErrorClick?.(error.line, error.column)
+              }
+            }}
           >
             {/* Icon */}
             <div className="flex-shrink-0 pt-0.5">

--- a/viz/src/index.css
+++ b/viz/src/index.css
@@ -56,3 +56,21 @@ body {
 canvas {
   display: block;
 }
+
+/* Monaco editor error line highlight */
+.error-line-highlight {
+  background-color: rgba(250, 204, 21, 0.3);
+  animation: error-highlight-fade 2s ease-out forwards;
+}
+
+@keyframes error-highlight-fade {
+  0% {
+    background-color: rgba(250, 204, 21, 0.3);
+  }
+  70% {
+    background-color: rgba(250, 204, 21, 0.3);
+  }
+  100% {
+    background-color: transparent;
+  }
+}

--- a/viz/src/pages/SimulationBuilder.tsx
+++ b/viz/src/pages/SimulationBuilder.tsx
@@ -7,7 +7,7 @@ import { ArrowLeft, HelpCircle, Eye, EyeOff, Ruler, Layers, Play, Pause, Grid3x3
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Slider } from '@/components/ui/slider'
-import { ScriptEditor } from '@/components/ScriptEditor'
+import { ScriptEditor, type ScriptEditorHandle } from '@/components/ScriptEditor'
 import { Preview3D } from '@/components/builder/Preview3D'
 import { TemplateBar } from '@/components/builder/TemplateBar'
 import { EstimationPanel } from '@/components/builder/EstimationPanel'
@@ -38,9 +38,15 @@ export function SimulationBuilder({ onBack }: SimulationBuilderProps) {
   const setIsAnimating = useBuilderStore((s) => s.setIsAnimating)
   const setAnimationSpeed = useBuilderStore((s) => s.setAnimationSpeed)
 
-  // Animation loop
+  // Refs
+  const scriptEditorRef = useRef<ScriptEditorHandle>(null)
   const animationRef = useRef<number | null>(null)
   const lastTimeRef = useRef<number>(0)
+
+  // Handle error click to jump to line in editor
+  const handleErrorClick = (line: number, column: number) => {
+    scriptEditorRef.current?.scrollToLine(line, column)
+  }
 
   useEffect(() => {
     if (!viewOptions.isAnimating || viewOptions.sliceAxis === 'none') {
@@ -157,6 +163,7 @@ export function SimulationBuilder({ onBack }: SimulationBuilderProps) {
 
           <div className="flex-1 overflow-hidden">
             <ScriptEditor
+              ref={scriptEditorRef}
               value={script}
               onChange={setScript}
               onSave={handleSave}
@@ -167,7 +174,7 @@ export function SimulationBuilder({ onBack }: SimulationBuilderProps) {
           {/* Error panel */}
           {validationErrors.length > 0 && (
             <div className="flex-shrink-0">
-              <ErrorPanel errors={validationErrors} />
+              <ErrorPanel errors={validationErrors} onErrorClick={handleErrorClick} />
             </div>
           )}
 


### PR DESCRIPTION
## Summary

- Clicking an error in the Builder Mode error panel now scrolls the editor to that line
- The error line is highlighted temporarily (2 seconds) with a yellow fade-out animation
- Editor receives focus after click, cursor is positioned at the error location
- Keyboard accessible via Enter/Space keys on error items

## Implementation

- **ScriptEditor.tsx**: Added `forwardRef` and `useImperativeHandle` to expose `scrollToLine` method
- **ErrorPanel.tsx**: Added `onErrorClick` prop with click handler and keyboard accessibility
- **SimulationBuilder.tsx**: Wired up editor ref and error click handler
- **index.css**: Added CSS for the error line highlight animation

## Test plan

- [ ] Open Simulation Builder with a Python script containing errors
- [ ] Click on an error in the error panel
- [ ] Verify editor scrolls to the error line and centers it
- [ ] Verify the line is highlighted yellow and fades out after ~2 seconds
- [ ] Verify the cursor is positioned at the error column
- [ ] Verify the editor receives focus
- [ ] Test keyboard navigation: Tab to error, press Enter/Space
- [ ] Repeat for both errors and warnings

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)