### PR TITLE
Add geometry clipping to slice plane viewer

### DIFF
--- a/viz/src/components/builder/MaterialRegion.tsx
+++ b/viz/src/components/builder/MaterialRegion.tsx
@@ -3,6 +3,7 @@
  */
 
 import { useMemo } from 'react'
+import * as THREE from 'three'
 import type { MaterialRegion as MaterialRegionType } from '@/lib/scriptParser'
 
 interface MaterialRegionProps {
@@ -13,6 +14,7 @@ interface MaterialRegionProps {
   dualSliceMode: boolean
   slice1Position: number
   slice2Position: number
+  clippingPlanes?: THREE.Plane[]
 }
 
 /**
@@ -34,7 +36,7 @@ function getMaterialColor(materialName: string): number {
   return MATERIAL_COLORS[materialName.toLowerCase()] ?? DEFAULT_COLOR
 }
 
-export function MaterialRegion({ region, sliceAxis, slicePosition, extent, dualSliceMode, slice1Position, slice2Position }: MaterialRegionProps) {
+export function MaterialRegion({ region, sliceAxis, slicePosition, extent, dualSliceMode, slice1Position, slice2Position, clippingPlanes = [] }: MaterialRegionProps) {
   const color = getMaterialColor(region.material)
 
   // Check if region intersects slice plane(s)
@@ -86,6 +88,9 @@ export function MaterialRegion({ region, sliceAxis, slicePosition, extent, dualS
           transparent
           opacity={0.6}
           depthWrite={false}
+          clippingPlanes={clippingPlanes}
+          clipShadows
+          side={THREE.DoubleSide}
         />
       </mesh>
     )
@@ -100,6 +105,9 @@ export function MaterialRegion({ region, sliceAxis, slicePosition, extent, dualS
           transparent
           opacity={0.6}
           depthWrite={false}
+          clippingPlanes={clippingPlanes}
+          clipShadows
+          side={THREE.DoubleSide}
         />
       </mesh>
     )


### PR DESCRIPTION
## Summary

- Implements true geometry clipping at slice plane positions using Three.js clipping planes
- Materials are now cut at the exact slice position, showing cross-sections (e.g., circular for spheres, rectangular for boxes)
- Supports both single slice mode and dual slice (slab) mode

## Changes

- **Preview3D.tsx**: Enable `localClippingEnabled` on Canvas, create clipping planes based on slice axis/position
- **MaterialRegion.tsx**: Apply clipping planes to material meshes with `DoubleSide` rendering for proper clipped surface visibility

## Test plan

- [ ] Select a slice axis (XY, XZ, or YZ) and verify geometry is clipped at the plane position
- [ ] Move the slice position slider and verify the clipped cross-section updates
- [ ] Test with a sphere to see circular cross-sections
- [ ] Test with a box to see rectangular cross-sections
- [ ] Enable dual slice mode and verify geometry is only visible between the two planes
- [ ] Set slice axis to "None" and verify no clipping occurs (full geometry visible)

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)