### PR TITLE
Fix pre-existing lint errors in source and test files

### DIFF
--- a/src/strata_fdtd/__init__.py
+++ b/src/strata_fdtd/__init__.py
@@ -9,56 +9,51 @@ Main exports:
 - Materials: Acoustic material library
 """
 
+# Re-export common analysis functions
+from strata_fdtd.analysis import (
+    apply_weighting,
+    calculate_leq,
+    calculate_spl,
+)
+from strata_fdtd.boundaries import PML, RadiationImpedance, RigidBoundary
+from strata_fdtd.core.grid import NonuniformGrid, UniformGrid
 from strata_fdtd.core.solver import (
+    POLAR_PATTERNS,
     FDTDSolver,
     GaussianPulse,
-    Probe,
     Microphone,
-    POLAR_PATTERNS,
+    Probe,
     has_native_kernels,
 )
 from strata_fdtd.core.solver_gpu import (
-    GPUFDTDSolver,
     BatchedGPUFDTDSolver,
+    GPUFDTDSolver,
     has_gpu_support,
 )
-from strata_fdtd.core.grid import UniformGrid, NonuniformGrid
-from strata_fdtd.boundaries import PML, RigidBoundary, RadiationImpedance
 
 # Re-export common geometry classes for convenience
 from strata_fdtd.geometry import (
     Box,
-    Sphere,
-    Cylinder,
     Cone,
-    Horn,
-    Union,
-    Intersection,
+    Cylinder,
     Difference,
-    SmoothUnion,
-    SmoothIntersection,
-    SmoothDifference,
-    Translate,
+    HelmholtzResonator,
+    Horn,
+    Intersection,
+    LoudspeakerEnclosure,
     Rotate,
     Scale,
     SDFPrimitive,
-    LoudspeakerEnclosure,
-    HelmholtzResonator,
-)
-
-# Re-export common analysis functions
-from strata_fdtd.analysis import (
-    apply_weighting,
-    calculate_spl,
-    calculate_leq,
+    SmoothDifference,
+    SmoothIntersection,
+    SmoothUnion,
+    Sphere,
+    Translate,
+    Union,
 )
 
 # Submodules for more specific imports
-from . import materials
-from . import geometry
-from . import manufacturing
-from . import io
-from . import analysis
+from . import analysis, geometry, io, manufacturing, materials
 
 __version__ = "0.1.0"
 

--- a/src/strata_fdtd/analysis/__init__.py
+++ b/src/strata_fdtd/analysis/__init__.py
@@ -3,8 +3,8 @@
 # Audio frequency weighting (A/C-weighting, SPL)
 from strata_fdtd.analysis.weighting import (
     apply_weighting,
-    calculate_spl,
     calculate_leq,
+    calculate_spl,
     weighting_response,
 )
 

--- a/src/strata_fdtd/boundaries/__init__.py
+++ b/src/strata_fdtd/boundaries/__init__.py
@@ -1,10 +1,10 @@
 """Boundary conditions for FDTD simulations."""
 
 from strata_fdtd.boundaries._boundaries import (
-    RigidBoundary,
     PML,
     ABCFirstOrder,
     RadiationImpedance,
+    RigidBoundary,
 )
 
 __all__ = [

--- a/src/strata_fdtd/core/__init__.py
+++ b/src/strata_fdtd/core/__init__.py
@@ -1,19 +1,19 @@
 """Core FDTD solver components."""
 
+from strata_fdtd.core.grid import NonuniformGrid, UniformGrid
 from strata_fdtd.core.solver import (
+    POLAR_PATTERNS,
     FDTDSolver,
     GaussianPulse,
-    Probe,
     Microphone,
-    POLAR_PATTERNS,
+    Probe,
     has_native_kernels,
 )
 from strata_fdtd.core.solver_gpu import (
-    GPUFDTDSolver,
     BatchedGPUFDTDSolver,
+    GPUFDTDSolver,
     has_gpu_support,
 )
-from strata_fdtd.core.grid import UniformGrid, NonuniformGrid
 
 __all__ = [
     "FDTDSolver",

--- a/src/strata_fdtd/core/solver.py
+++ b/src/strata_fdtd/core/solver.py
@@ -67,10 +67,11 @@ from numpy.typing import NDArray
 from .grid import NonuniformGrid, UniformGrid
 
 if TYPE_CHECKING:
+    from strata_fdtd.analysis.weighting import WeightingType
+
     from .grid import NonuniformGrid, UniformGrid
     from .material_geometry import MaterializedGeometry
     from .sdf import SDFPrimitive
-    from strata_fdtd.analysis.weighting import WeightingType
 
 # =============================================================================
 # Native C++ Extension Support

--- a/src/strata_fdtd/geometry/__init__.py
+++ b/src/strata_fdtd/geometry/__init__.py
@@ -1,38 +1,26 @@
 """Geometric modeling for FDTD simulations."""
 
 # SDF primitives and CSG operations
-from strata_fdtd.geometry.sdf import (
-    # Base SDF class
-    SDFPrimitive,
-    # Primitives
-    Box,
-    Sphere,
-    Cylinder,
-    Cone,
-    Horn,
-    HelicalTube,
-    SpiralHorn,
-    # CSG operations
-    Union,
-    Intersection,
-    Difference,
-    SmoothUnion,
-    SmoothIntersection,
-    SmoothDifference,
-    # Transformations
-    Translate,
-    Rotate,
-    Scale,
+# Loudspeaker enclosures
+from strata_fdtd.geometry.loudspeaker import (
+    LoudspeakerEnclosure,
+    bookshelf_speaker,
+    tower_speaker,
 )
 
-# Metamaterial primitives
-from strata_fdtd.geometry.primitives import (
-    HelmholtzCell,
-    Channel,
-    TaperedChannel,
-    SerpentineChannel,
-    SphereCell,
-    SphereLattice,
+# Material assignment
+from strata_fdtd.geometry.material_assignment import (
+    MaterializedGeometry,
+    MaterialVolume,
+)
+
+# Parametric geometry
+from strata_fdtd.geometry.parametric import (
+    ConstraintSet,
+    GeometryOptimizer,
+    Parameter,
+    ParametricHorn,
+    ParametricPrimitive,
 )
 
 # Path generation
@@ -41,11 +29,14 @@ from strata_fdtd.geometry.paths import (
     SpiralPath,
 )
 
-# Loudspeaker enclosures
-from strata_fdtd.geometry.loudspeaker import (
-    LoudspeakerEnclosure,
-    tower_speaker,
-    bookshelf_speaker,
+# Metamaterial primitives
+from strata_fdtd.geometry.primitives import (
+    Channel,
+    HelmholtzCell,
+    SerpentineChannel,
+    SphereCell,
+    SphereLattice,
+    TaperedChannel,
 )
 
 # Helmholtz resonators
@@ -53,20 +44,28 @@ from strata_fdtd.geometry.resonator import (
     HelmholtzResonator,
     helmholtz_array,
 )
-
-# Parametric geometry
-from strata_fdtd.geometry.parametric import (
-    Parameter,
-    ParametricPrimitive,
-    ParametricHorn,
-    GeometryOptimizer,
-    ConstraintSet,
-)
-
-# Material assignment
-from strata_fdtd.geometry.material_assignment import (
-    MaterializedGeometry,
-    MaterialVolume,
+from strata_fdtd.geometry.sdf import (
+    # Primitives
+    Box,
+    Cone,
+    Cylinder,
+    Difference,
+    HelicalTube,
+    Horn,
+    Intersection,
+    Rotate,
+    Scale,
+    # Base SDF class
+    SDFPrimitive,
+    SmoothDifference,
+    SmoothIntersection,
+    SmoothUnion,
+    Sphere,
+    SpiralHorn,
+    # Transformations
+    Translate,
+    # CSG operations
+    Union,
 )
 
 __all__ = [

--- a/src/strata_fdtd/geometry/material_assignment.py
+++ b/src/strata_fdtd/geometry/material_assignment.py
@@ -39,9 +39,9 @@ import numpy as np
 from numpy.typing import NDArray
 
 if TYPE_CHECKING:
+    from strata_fdtd.geometry.sdf import Box, SDFPrimitive
     from strata_fdtd.grid import NonuniformGrid, UniformGrid
     from strata_fdtd.materials.base import AcousticMaterial
-    from strata_fdtd.geometry.sdf import Box, SDFPrimitive
 
 
 @dataclass

--- a/src/strata_fdtd/geometry/parametric.py
+++ b/src/strata_fdtd/geometry/parametric.py
@@ -40,8 +40,8 @@ import numpy as np
 from numpy.typing import NDArray
 
 if TYPE_CHECKING:
-    from strata_fdtd.grid import UniformGrid
     from strata_fdtd.geometry.sdf import Horn, SDFPrimitive
+    from strata_fdtd.grid import UniformGrid
 
 
 @dataclass

--- a/src/strata_fdtd/io/__init__.py
+++ b/src/strata_fdtd/io/__init__.py
@@ -2,17 +2,21 @@
 
 # HDF5 I/O
 from strata_fdtd.io.hdf5 import (
-    HDF5ResultWriter,
     HDF5ResultReader,
+    HDF5ResultWriter,
+)
+from strata_fdtd.io.output import (
+    HDF5ResultReader as OutputHDF5Reader,
 )
 
 # Output management
 from strata_fdtd.io.output import (
     HDF5ResultWriter as OutputHDF5Writer,
-    HDF5ResultReader as OutputHDF5Reader,
 )
 
 __all__ = [
     "HDF5ResultWriter",
     "HDF5ResultReader",
+    "OutputHDF5Writer",
+    "OutputHDF5Reader",
 ]

--- a/src/strata_fdtd/manufacturing/__init__.py
+++ b/src/strata_fdtd/manufacturing/__init__.py
@@ -1,17 +1,11 @@
 """Manufacturing tools for lamination, constraints, and export."""
 
 # Lamination (Slice/Stack geometry)
-from strata_fdtd.manufacturing.lamination import (
-    Slice,
-    Stack,
-    Violation,
-)
-
 # Manufacturing constraints
 from strata_fdtd.manufacturing.constraints import (
     check_connectivity,
-    check_min_wall,
     check_min_gap,
+    check_min_wall,
     check_slice_alignment,
 )
 
@@ -25,8 +19,13 @@ from strata_fdtd.manufacturing.conversion import (
 # CAD export (DXF, STL, JSON)
 from strata_fdtd.manufacturing.export import (
     export_dxf,
-    export_stl,
     export_json,
+    export_stl,
+)
+from strata_fdtd.manufacturing.lamination import (
+    Slice,
+    Stack,
+    Violation,
 )
 
 __all__ = [

--- a/tests/test_fdtd.py
+++ b/tests/test_fdtd.py
@@ -1130,8 +1130,8 @@ class TestNonuniformGridNative:
 
     def test_nonuniform_native_fdtd_step(self):
         """Verify native nonuniform FDTD step matches Python implementation."""
-        from strata_fdtd.core.solver import has_native_kernels
         from strata_fdtd.core.grid import NonuniformGrid
+        from strata_fdtd.core.solver import has_native_kernels
 
         if not has_native_kernels():
             pytest.skip("Native kernels not available")
@@ -1170,8 +1170,8 @@ class TestNonuniformGridNative:
 
     def test_nonuniform_native_uses_correct_backend(self):
         """Verify native backend is actually used for nonuniform grids."""
-        from strata_fdtd.core.solver import has_native_kernels
         from strata_fdtd.core.grid import NonuniformGrid
+        from strata_fdtd.core.solver import has_native_kernels
 
         if not has_native_kernels():
             pytest.skip("Native kernels not available")
@@ -1188,8 +1188,8 @@ class TestNonuniformGridNative:
 
     def test_nonuniform_native_energy_conservation(self):
         """Verify energy is conserved with nonuniform grid and native backend."""
-        from strata_fdtd.core.solver import has_native_kernels
         from strata_fdtd.core.grid import NonuniformGrid
+        from strata_fdtd.core.solver import has_native_kernels
 
         if not has_native_kernels():
             pytest.skip("Native kernels not available")
@@ -1223,8 +1223,8 @@ class TestNonuniformGridNative:
     @pytest.mark.parametrize("backend", ["python", "native"])
     def test_nonuniform_divergence_consistency(self, backend):
         """Verify divergence computation matches between backends."""
-        from strata_fdtd.core.solver import has_native_kernels
         from strata_fdtd.core.grid import NonuniformGrid
+        from strata_fdtd.core.solver import has_native_kernels
 
         if backend == "native" and not has_native_kernels():
             pytest.skip("Native kernels not available")

--- a/tests/test_fdtd_output.py
+++ b/tests/test_fdtd_output.py
@@ -9,7 +9,6 @@ import numpy as np
 import pytest
 
 from strata_fdtd import (
-    PML,
     FDTDSolver,
     GaussianPulse,
     UniformGrid,
@@ -243,7 +242,7 @@ def test_hdf5_reader_load_probe(small_solver, temp_h5_file):
     # Load probe data - note: probe data may be empty if not written during simulation
     # This test just verifies the API works
     try:
-        probe_data = reader.load_probe('center')
+        reader.load_probe('center')
         # If we got here, the probe exists (data may or may not be populated)
     except KeyError:
         pytest.fail("Probe 'center' should exist")

--- a/tests/test_material_geometry.py
+++ b/tests/test_material_geometry.py
@@ -14,9 +14,9 @@ import pytest
 
 from strata_fdtd import UniformGrid
 from strata_fdtd.geometry import MaterializedGeometry, MaterialVolume
+from strata_fdtd.geometry.sdf import Box
 from strata_fdtd.materials.base import SimpleMaterial
 from strata_fdtd.materials.library import FIBERGLASS_48
-from strata_fdtd.geometry.sdf import Box
 
 
 class TestMaterializedGeometry:


### PR DESCRIPTION
## Summary
- Auto-fix import sorting issues (I001) across 11 source and test modules using `ruff --fix`
- Remove unused import `PML` from test_fdtd_output.py (F401)
- Remove unused local variable `probe_data` in test_hdf5_reader_load_probe (F841)
- Add `OutputHDF5Writer` and `OutputHDF5Reader` to io/__init__.py `__all__` to resolve F401 warnings

## Test plan
- [x] Run `uv run ruff check src/ tests/` - all checks pass
- [ ] CI lint check should now pass on all PRs

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)