### PR TITLE
Set up CI/CD for automated desktop app builds and releases

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -1,0 +1,147 @@
+name: Desktop App Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag (e.g., v0.1.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    outputs:
+      release_id: ${{ steps.create-release.outputs.id }}
+      upload_url: ${{ steps.create-release.outputs.upload_url }}
+    steps:
+      - name: Determine tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create Release
+        id: create-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: FDTD Simulator ${{ steps.tag.outputs.tag }}
+          draft: true
+          prerelease: false
+          generate_release_notes: true
+
+  build-tauri:
+    needs: create-release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest
+            args: --target universal-apple-darwin
+            name: macOS
+          - platform: ubuntu-22.04
+            args: ''
+            name: Linux
+          - platform: windows-latest
+            args: ''
+            name: Windows
+
+    runs-on: ${{ matrix.platform }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: './strata-app/src-tauri -> target'
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build Tauri App
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # macOS code signing (optional - requires Apple Developer account)
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          # Windows code signing (optional - requires code signing certificate)
+          WINDOWS_CERTIFICATE: ${{ secrets.WINDOWS_CERTIFICATE }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.WINDOWS_CERTIFICATE_PASSWORD }}
+          # Tauri updater signing key (optional - for auto-updates)
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          projectPath: strata-app
+          tagName: ${{ needs.create-release.outputs.release_id && '' }}
+          releaseName: 'FDTD Simulator v__VERSION__'
+          releaseBody: 'See the assets to download and install this version.'
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+
+  publish-release:
+    needs: [create-release, build-tauri]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish Release
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Release stays as draft - maintainer publishes manually
+            console.log('Release created as draft. Visit the releases page to publish.');
+            console.log('Release ID: ${{ needs.create-release.outputs.release_id }}');

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,109 @@
+name: Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'New version (e.g., 0.2.0) - without the v prefix'
+        required: true
+        type: string
+      create_tag:
+        description: 'Create and push tag after version bump'
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Error: Version must be in semver format (e.g., 0.2.0)"
+            exit 1
+          fi
+
+      - name: Update strata-app package.json
+        run: |
+          cd strata-app
+          npm version ${{ inputs.version }} --no-git-tag-version
+          echo "Updated strata-app/package.json to ${{ inputs.version }}"
+
+      - name: Update strata-web package.json
+        run: |
+          cd strata-web
+          npm version ${{ inputs.version }} --no-git-tag-version
+          echo "Updated strata-web/package.json to ${{ inputs.version }}"
+
+      - name: Update strata-ui package.json
+        run: |
+          cd strata-ui
+          npm version ${{ inputs.version }} --no-git-tag-version
+          echo "Updated strata-ui/package.json to ${{ inputs.version }}"
+
+      - name: Update Cargo.toml version
+        run: |
+          cd strata-app/src-tauri
+          sed -i 's/^version = ".*"/version = "${{ inputs.version }}"/' Cargo.toml
+          echo "Updated strata-app/src-tauri/Cargo.toml to ${{ inputs.version }}"
+
+      - name: Update tauri.conf.json version
+        run: |
+          cd strata-app/src-tauri
+          # Use jq to update the version field
+          jq '.version = "${{ inputs.version }}"' tauri.conf.json > tmp.json
+          mv tmp.json tauri.conf.json
+          echo "Updated strata-app/src-tauri/tauri.conf.json to ${{ inputs.version }}"
+
+      - name: Update pyproject.toml version
+        run: |
+          sed -i 's/^version = ".*"/version = "${{ inputs.version }}"/' pyproject.toml
+          echo "Updated pyproject.toml to ${{ inputs.version }}"
+
+      - name: Commit version changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: bump version to v${{ inputs.version }}"
+          git push origin main
+
+      - name: Create and push tag
+        if: ${{ inputs.create_tag }}
+        run: |
+          git tag v${{ inputs.version }}
+          git push origin v${{ inputs.version }}
+          echo "Created and pushed tag v${{ inputs.version }}"
+
+      - name: Summary
+        run: |
+          echo "## Version Bump Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- **New Version**: v${{ inputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Tag Created**: ${{ inputs.create_tag }}" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Files Updated" >> $GITHUB_STEP_SUMMARY
+          echo "- strata-app/package.json" >> $GITHUB_STEP_SUMMARY
+          echo "- strata-web/package.json" >> $GITHUB_STEP_SUMMARY
+          echo "- strata-ui/package.json" >> $GITHUB_STEP_SUMMARY
+          echo "- strata-app/src-tauri/Cargo.toml" >> $GITHUB_STEP_SUMMARY
+          echo "- strata-app/src-tauri/tauri.conf.json" >> $GITHUB_STEP_SUMMARY
+          echo "- pyproject.toml" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ inputs.create_tag }}" = "true" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "The tag v${{ inputs.version }} will trigger the Desktop App Release workflow." >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
## Summary

Add GitHub Actions workflows for automated desktop app builds and releases:

- **desktop-release.yml**: Triggered on version tags (v*.*.*), builds installers for all platforms
- **version-bump.yml**: Manual workflow to update versions across all packages and optionally trigger a release

## Changes

### New Workflows

**Desktop Release (`desktop-release.yml`)**
- Builds for macOS (universal binary), Linux (x64), Windows (x64)
- Creates draft GitHub release with all installers attached
- Supports optional code signing for macOS (Apple Developer) and Windows
- Supports Tauri auto-updater signing for seamless app updates
- Uses official tauri-action for reliable cross-platform builds

**Version Bump (`version-bump.yml`)**
- Manual workflow accessible from Actions tab
- Updates version in all relevant files:
  - strata-app/package.json
  - strata-web/package.json
  - strata-ui/package.json
  - strata-app/src-tauri/Cargo.toml
  - strata-app/src-tauri/tauri.conf.json
  - pyproject.toml
- Optionally creates and pushes version tag (which triggers desktop-release)

### Documentation Updates

- Updated docs/ci-cd.md with new workflow documentation
- Added Windows code signing secrets to the secrets table
- Fixed repository name references (was referencing old repo name)
- Added detailed release process instructions

## How to Use

### Creating a Release

1. Go to **Actions → Version Bump**
2. Enter version (e.g., `0.2.0`)
3. Check "Create and push tag"
4. Run workflow

The version bump commits changes, creates tag, and triggers the desktop release automatically.

### Code Signing (Optional)

For signed releases, configure these secrets:

**macOS**: `APPLE_CERTIFICATE`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_PASSWORD`, `APPLE_TEAM_ID`

**Windows**: `WINDOWS_CERTIFICATE`, `WINDOWS_CERTIFICATE_PASSWORD`

**Auto-Update**: `TAURI_SIGNING_PRIVATE_KEY`, `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`

## Test Plan

- [x] Workflow YAML files have valid syntax
- [ ] Trigger version-bump workflow manually and verify version updates
- [ ] Create test tag to verify desktop-release workflow builds all platforms
- [ ] Verify draft release is created with installer attachments

Closes #15