### PR TITLE
Integrate Tauri file picker into web UI components

### DIFF
--- a/strata-ui/src/lib/loaders/hdf5.ts
+++ b/strata-ui/src/lib/loaders/hdf5.ts
@@ -180,6 +180,22 @@ export async function loadHDF5File(
 }
 
 /**
+ * Load simulation data from a raw buffer.
+ *
+ * Used when file data is already in memory (e.g., from Tauri's fs.readBinaryFile).
+ *
+ * @param buffer - File content as Uint8Array
+ * @param filename - Name for the virtual file
+ * @returns Parsed simulation data
+ */
+export async function loadHDF5FromBuffer(
+  buffer: Uint8Array,
+  filename: string = "simulation.h5"
+): Promise<HDF5SimulationData> {
+  return parseHDF5Buffer(buffer, filename);
+}
+
+/**
  * Load simulation data from a URL.
  *
  * Returns both the parsed data and the raw buffer to avoid needing to

--- a/strata-ui/src/lib/loaders/index.ts
+++ b/strata-ui/src/lib/loaders/index.ts
@@ -81,6 +81,7 @@ export {
 // HDF5 loader
 export {
   loadHDF5File,
+  loadHDF5FromBuffer,
   loadHDF5FromURL,
   loadTimestep,
   toSimulationMetadata,


### PR DESCRIPTION
## Summary

- Add `loadHDF5FromBuffer` export to strata-ui for loading HDF5 from raw buffers
- Add `loadPath` method to `useHDF5Simulation` hook for Tauri file system loading
- Update `FileUpload` component to accept native file dialog integration props
- Add Tauri event listeners in `App.tsx` for `open-file` and `navigate` events
- Update `ViewerPage` to use native file picker when in Tauri and auto-load initial files from events

This enables the desktop app to use Tauri's native file picker dialog while maintaining full compatibility with the web version's file input fallback.

## Test plan

- [ ] Test file picker in desktop app (`pnpm tauri:dev`)
- [ ] Verify web version still works in browser without Tauri
- [ ] Test file open events (via system tray when implemented)
- [ ] Test navigation events work correctly
- [ ] Verify error handling for invalid files

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)