### PR TITLE
Add AudioFileWaveform source for playing audio through simulation

### DIFF
--- a/src/strata_fdtd/__init__.py
+++ b/src/strata_fdtd/__init__.py
@@ -5,6 +5,7 @@ Main exports:
 - FDTDSolver: Core 3D acoustic FDTD solver
 - GPUFDTDSolver: GPU-accelerated solver
 - GaussianPulse: Point/plane acoustic source
+- AudioFileWaveform: Audio file source waveform
 - MembraneSource: Spatially-distributed source with modal patterns
 - PML: Absorbing boundary
 - Materials: Acoustic material library
@@ -34,6 +35,7 @@ from strata_fdtd.core.solver_gpu import (
     GPUFDTDSolver,
     has_gpu_support,
 )
+from strata_fdtd.core.waveforms import AudioFileWaveform
 
 # Re-export common geometry classes for convenience
 from strata_fdtd.geometry import (
@@ -67,6 +69,7 @@ __all__ = [
     "GPUFDTDSolver",
     "BatchedGPUFDTDSolver",
     "GaussianPulse",
+    "AudioFileWaveform",
     "MembraneSource",
     "CircularMembraneSource",
     "RectangularMembraneSource",

--- a/src/strata_fdtd/core/__init__.py
+++ b/src/strata_fdtd/core/__init__.py
@@ -14,12 +14,14 @@ from strata_fdtd.core.solver_gpu import (
     GPUFDTDSolver,
     has_gpu_support,
 )
+from strata_fdtd.core.waveforms import AudioFileWaveform
 
 __all__ = [
     "FDTDSolver",
     "GPUFDTDSolver",
     "BatchedGPUFDTDSolver",
     "GaussianPulse",
+    "AudioFileWaveform",
     "Probe",
     "Microphone",
     "POLAR_PATTERNS",

--- a/src/strata_fdtd/core/waveforms.py
+++ b/src/strata_fdtd/core/waveforms.py
@@ -1,0 +1,231 @@
+"""Audio waveform sources for FDTD simulation.
+
+This module provides waveform classes that load audio from files
+and provide them as source signals for FDTD acoustic simulation.
+
+Classes:
+    AudioFileWaveform: Load audio files (WAV, MP3, FLAC) as source waveforms
+
+Example:
+    >>> from strata_fdtd import AudioFileWaveform, CircularMembraneSource
+    >>> waveform = AudioFileWaveform("test_tone.wav", amplitude=0.5)
+    >>> source = CircularMembraneSource(
+    ...     center=(0.1, 0.01, 0.15),
+    ...     radius=0.1,
+    ...     normal_axis='y',
+    ...     waveform=waveform,
+    ... )
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+from numpy.typing import NDArray
+from scipy import signal
+from scipy.io import wavfile
+
+
+@dataclass
+class AudioFileWaveform:
+    """Audio file source waveform for FDTD simulation.
+
+    Loads audio from file, resamples to simulation sample rate,
+    and provides pressure values at each timestep. Compatible with
+    GaussianPulse interface for use with membrane sources.
+
+    Args:
+        filepath: Path to audio file (WAV natively, MP3/FLAC via soundfile)
+        amplitude: Peak amplitude scaling (default 1.0)
+        channel: Which channel to use for stereo files (0=left, 1=right, 'mix'=average)
+        start_time: Start position in audio file (seconds)
+        duration: Duration to use (None = entire file)
+        loop: Whether to loop audio when end is reached
+
+    Example:
+        >>> waveform = AudioFileWaveform("test_tone.wav", amplitude=0.5)
+        >>> # Use with membrane source
+        >>> from strata_fdtd import CircularMembraneSource, GaussianPulse
+        >>> source = CircularMembraneSource(
+        ...     center=(0.1, 0.01, 0.15),
+        ...     radius=0.1,
+        ...     normal_axis='y',
+        ...     waveform=waveform,
+        ... )
+
+    Note:
+        FDTD simulations typically use very small timesteps (dt ~ 8 µs at 5mm
+        resolution), corresponding to sample rates of ~120 kHz or higher.
+        Audio files (typically 44.1/48 kHz) are automatically upsampled.
+    """
+
+    filepath: str | Path
+    amplitude: float = 1.0
+    channel: int | Literal["mix"] = "mix"
+    start_time: float = 0.0
+    duration: float | None = None
+    loop: bool = False
+
+    # Internal state (not part of public interface)
+    _samples: NDArray[np.floating] | None = field(
+        default=None, init=False, repr=False
+    )
+    _native_sr: int | None = field(default=None, init=False, repr=False)
+    _resampled: dict[int, NDArray[np.floating]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    def __post_init__(self) -> None:
+        """Load and preprocess audio file."""
+        self._load_audio()
+
+    def _load_audio(self) -> None:
+        """Load and preprocess audio file.
+
+        Handles WAV files natively via scipy.io.wavfile.
+        Other formats (MP3, FLAC, OGG) require the optional soundfile package.
+
+        Raises:
+            FileNotFoundError: If audio file doesn't exist
+            ImportError: If soundfile is needed but not installed
+        """
+        filepath = Path(self.filepath)
+        if not filepath.exists():
+            raise FileNotFoundError(f"Audio file not found: {filepath}")
+
+        # Load audio using appropriate library
+        if filepath.suffix.lower() == ".wav":
+            sr, data = wavfile.read(filepath)
+        else:
+            # Use soundfile for other formats (MP3, FLAC, OGG, etc.)
+            try:
+                import soundfile as sf
+            except ImportError as e:
+                raise ImportError(
+                    f"soundfile package required for {filepath.suffix} files. "
+                    "Install with: pip install soundfile"
+                ) from e
+            data, sr = sf.read(filepath)
+
+        self._native_sr = sr
+
+        # Convert to float32 normalized to [-1, 1]
+        if data.dtype == np.int16:
+            data = data.astype(np.float32) / 32768.0
+        elif data.dtype == np.int32:
+            data = data.astype(np.float32) / 2147483648.0
+        elif data.dtype == np.uint8:
+            data = (data.astype(np.float32) - 128) / 128.0
+        elif data.dtype in (np.float32, np.float64):
+            data = data.astype(np.float32)
+        else:
+            # Attempt generic conversion
+            data = data.astype(np.float32)
+
+        # Handle stereo -> mono
+        if len(data.shape) > 1:
+            if self.channel == "mix":
+                data = np.mean(data, axis=1)
+            else:
+                if self.channel >= data.shape[1]:
+                    raise ValueError(
+                        f"Channel {self.channel} requested but file only has "
+                        f"{data.shape[1]} channels"
+                    )
+                data = data[:, self.channel]
+
+        # Apply start/duration trimming
+        start_sample = int(self.start_time * sr)
+        if start_sample >= len(data):
+            raise ValueError(
+                f"start_time {self.start_time}s is beyond end of file "
+                f"({len(data) / sr:.2f}s)"
+            )
+
+        if self.duration is not None:
+            end_sample = start_sample + int(self.duration * sr)
+            data = data[start_sample:end_sample]
+        else:
+            data = data[start_sample:]
+
+        self._samples = data.astype(np.float32)
+
+    def _resample_for_dt(self, dt: float) -> NDArray[np.floating]:
+        """Resample audio to simulation timestep.
+
+        Uses scipy.signal.resample for high-quality resampling.
+        Results are cached by target sample rate.
+
+        Args:
+            dt: Simulation timestep in seconds
+
+        Returns:
+            Resampled audio array
+        """
+        target_sr = int(round(1.0 / dt))
+
+        if target_sr in self._resampled:
+            return self._resampled[target_sr]
+
+        if target_sr == self._native_sr:
+            resampled = self._samples
+        else:
+            # Resample using scipy's polyphase resampler
+            num_samples = int(len(self._samples) * target_sr / self._native_sr)
+            resampled = signal.resample(self._samples, num_samples).astype(np.float32)
+
+        self._resampled[target_sr] = resampled
+        return resampled
+
+    def waveform(
+        self, t: NDArray[np.floating], dt: float
+    ) -> NDArray[np.floating]:
+        """Get waveform values at specified times.
+
+        Interface matches GaussianPulse.waveform() for compatibility
+        with membrane sources and other FDTD components.
+
+        Args:
+            t: Array of time values in seconds
+            dt: Simulation timestep in seconds
+
+        Returns:
+            Pressure values at each time, scaled by amplitude
+        """
+        resampled = self._resample_for_dt(dt)
+
+        # Convert times to sample indices
+        indices = (t / dt).astype(np.int64)
+
+        if self.loop:
+            # Wrap indices for looping
+            indices = indices % len(resampled)
+            return self.amplitude * resampled[indices]
+        else:
+            # Clamp to valid range, return 0 past end
+            valid = (indices >= 0) & (indices < len(resampled))
+            result = np.zeros_like(t, dtype=np.float32)
+            result[valid] = resampled[indices[valid]]
+            return self.amplitude * result
+
+    @property
+    def duration_seconds(self) -> float:
+        """Total duration of loaded audio in seconds."""
+        if self._samples is None or self._native_sr is None:
+            return 0.0
+        return len(self._samples) / self._native_sr
+
+    @property
+    def native_sample_rate(self) -> int:
+        """Original sample rate of audio file."""
+        return self._native_sr or 0
+
+    @property
+    def num_samples(self) -> int:
+        """Number of samples in loaded audio."""
+        if self._samples is None:
+            return 0
+        return len(self._samples)

--- a/tests/test_waveforms.py
+++ b/tests/test_waveforms.py
@@ -1,0 +1,465 @@
+"""
+Unit tests for audio waveform sources.
+
+Tests verify:
+- AudioFileWaveform loading (WAV files)
+- Sample rate conversion and resampling
+- Stereo to mono conversion
+- Start time and duration trimming
+- Loop functionality
+- Compatibility with GaussianPulse interface
+"""
+
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy.io import wavfile
+
+from strata_fdtd import AudioFileWaveform
+
+
+class TestAudioFileWaveformLoading:
+    """Tests for AudioFileWaveform file loading."""
+
+    def test_load_16bit_wav(self, tmp_path):
+        """Test loading 16-bit WAV file."""
+        # Create test WAV file
+        sr = 44100
+        duration = 0.1
+        t = np.linspace(0, duration, int(sr * duration), endpoint=False)
+        data = (np.sin(2 * np.pi * 440 * t) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test_16bit.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath)
+
+        assert waveform.native_sample_rate == sr
+        assert waveform.num_samples == len(data)
+        assert abs(waveform.duration_seconds - duration) < 0.001
+
+    def test_load_32bit_float_wav(self, tmp_path):
+        """Test loading 32-bit float WAV file."""
+        sr = 48000
+        duration = 0.1
+        t = np.linspace(0, duration, int(sr * duration), endpoint=False)
+        data = np.sin(2 * np.pi * 440 * t).astype(np.float32)
+
+        filepath = tmp_path / "test_32bit.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath)
+
+        assert waveform.native_sample_rate == sr
+        assert waveform.num_samples == len(data)
+
+    def test_load_stereo_mix(self, tmp_path):
+        """Test loading stereo file and mixing to mono."""
+        sr = 44100
+        duration = 0.1
+        n_samples = int(sr * duration)
+        # Left channel: 440Hz, Right channel: 880Hz
+        left = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+        right = (np.sin(2 * np.pi * 880 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+        data = np.column_stack([left, right])
+
+        filepath = tmp_path / "test_stereo.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath, channel="mix")
+
+        assert waveform.native_sample_rate == sr
+        assert waveform.num_samples == n_samples
+
+    def test_load_stereo_left_channel(self, tmp_path):
+        """Test loading stereo file and selecting left channel."""
+        sr = 44100
+        duration = 0.1
+        n_samples = int(sr * duration)
+        left = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+        right = (np.sin(2 * np.pi * 880 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+        data = np.column_stack([left, right])
+
+        filepath = tmp_path / "test_stereo.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath, channel=0)
+
+        assert waveform.num_samples == n_samples
+
+    def test_load_stereo_right_channel(self, tmp_path):
+        """Test loading stereo file and selecting right channel."""
+        sr = 44100
+        duration = 0.1
+        n_samples = int(sr * duration)
+        left = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+        right = (np.sin(2 * np.pi * 880 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+        data = np.column_stack([left, right])
+
+        filepath = tmp_path / "test_stereo.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath, channel=1)
+
+        assert waveform.num_samples == n_samples
+
+    def test_file_not_found(self):
+        """Test error handling for missing file."""
+        with pytest.raises(FileNotFoundError, match="Audio file not found"):
+            AudioFileWaveform("/nonexistent/path/audio.wav")
+
+    def test_invalid_channel(self, tmp_path):
+        """Test error handling for invalid channel index."""
+        sr = 44100
+        duration = 0.1
+        n_samples = int(sr * duration)
+        left = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+        right = (np.sin(2 * np.pi * 880 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+        data = np.column_stack([left, right])
+
+        filepath = tmp_path / "test_stereo.wav"
+        wavfile.write(filepath, sr, data)
+
+        with pytest.raises(ValueError, match="Channel 5 requested but file only has 2 channels"):
+            AudioFileWaveform(filepath, channel=5)
+
+
+class TestAudioFileWaveformTrimming:
+    """Tests for start time and duration trimming."""
+
+    def test_start_time(self, tmp_path):
+        """Test loading with start time offset."""
+        sr = 44100
+        duration = 1.0
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath, start_time=0.5)
+
+        # Should have half the samples
+        expected_samples = int(sr * 0.5)
+        assert abs(waveform.num_samples - expected_samples) < 2
+        assert abs(waveform.duration_seconds - 0.5) < 0.001
+
+    def test_duration(self, tmp_path):
+        """Test loading with duration limit."""
+        sr = 44100
+        duration = 1.0
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath, duration=0.25)
+
+        expected_samples = int(sr * 0.25)
+        assert abs(waveform.num_samples - expected_samples) < 2
+        assert abs(waveform.duration_seconds - 0.25) < 0.001
+
+    def test_start_time_and_duration(self, tmp_path):
+        """Test loading with both start time and duration."""
+        sr = 44100
+        duration = 1.0
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath, start_time=0.25, duration=0.25)
+
+        expected_samples = int(sr * 0.25)
+        assert abs(waveform.num_samples - expected_samples) < 2
+
+    def test_start_time_past_end(self, tmp_path):
+        """Test error when start_time is past end of file."""
+        sr = 44100
+        duration = 0.1
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        with pytest.raises(ValueError, match="start_time.*is beyond end of file"):
+            AudioFileWaveform(filepath, start_time=1.0)
+
+
+class TestAudioFileWaveformResampling:
+    """Tests for resampling to simulation timestep."""
+
+    def test_resample_to_higher_rate(self, tmp_path):
+        """Test upsampling to higher simulation rate."""
+        sr = 44100
+        duration = 0.01
+        freq = 1000
+        n_samples = int(sr * duration)
+        t = np.linspace(0, duration, n_samples, endpoint=False)
+        data = (np.sin(2 * np.pi * freq * t) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath)
+
+        # Simulate typical FDTD timestep (dt ~ 8µs = 125 kHz)
+        dt = 8e-6
+        sim_t = np.arange(0, duration, dt)
+
+        result = waveform.waveform(sim_t, dt)
+
+        assert len(result) == len(sim_t)
+        # Check amplitude is reasonable (normalized)
+        assert np.max(np.abs(result)) <= 1.1
+
+    def test_resample_preserves_frequency(self, tmp_path):
+        """Test that resampling preserves frequency content."""
+        sr = 44100
+        duration = 0.1
+        freq = 440  # A4
+        n_samples = int(sr * duration)
+        t = np.linspace(0, duration, n_samples, endpoint=False)
+        data = (np.sin(2 * np.pi * freq * t) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath)
+
+        # Resample to 100 kHz
+        dt = 1e-5
+        sim_t = np.arange(0, duration, dt)
+        result = waveform.waveform(sim_t, dt)
+
+        # Check via FFT that fundamental frequency is preserved
+        fft = np.fft.fft(result)
+        freqs = np.fft.fftfreq(len(result), dt)
+        peak_idx = np.argmax(np.abs(fft[:len(fft)//2]))
+        peak_freq = abs(freqs[peak_idx])
+
+        # Allow 5% tolerance
+        assert abs(peak_freq - freq) < freq * 0.05
+
+    def test_resample_caching(self, tmp_path):
+        """Test that resampled results are cached."""
+        sr = 44100
+        duration = 0.01
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath)
+
+        dt = 1e-5
+        sim_t = np.arange(0, duration, dt)
+
+        # First call
+        result1 = waveform.waveform(sim_t, dt)
+        # Second call should use cache
+        result2 = waveform.waveform(sim_t, dt)
+
+        np.testing.assert_array_equal(result1, result2)
+
+
+class TestAudioFileWaveformInterface:
+    """Tests for GaussianPulse-compatible interface."""
+
+    def test_waveform_method_signature(self, tmp_path):
+        """Test that waveform method has correct signature."""
+        sr = 44100
+        duration = 0.1
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath)
+
+        # Test waveform method works like GaussianPulse
+        dt = 1e-5
+        t = np.array([0.0, 0.001, 0.002])
+
+        result = waveform.waveform(t, dt)
+
+        assert isinstance(result, np.ndarray)
+        assert result.shape == t.shape
+
+    def test_amplitude_scaling(self, tmp_path):
+        """Test amplitude parameter scales output."""
+        sr = 44100
+        duration = 0.01
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform1 = AudioFileWaveform(filepath, amplitude=1.0)
+        waveform2 = AudioFileWaveform(filepath, amplitude=0.5)
+
+        dt = 1e-5
+        t = np.arange(0, duration, dt)
+
+        result1 = waveform1.waveform(t, dt)
+        result2 = waveform2.waveform(t, dt)
+
+        # Amplitude 0.5 should give half the values
+        np.testing.assert_allclose(result2, result1 * 0.5, rtol=1e-5)
+
+    def test_past_end_returns_zero(self, tmp_path):
+        """Test that requesting times past end returns zero."""
+        sr = 44100
+        duration = 0.1
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath, loop=False)
+
+        dt = 1e-5
+        # Request times well past end of file
+        t = np.array([0.5, 1.0, 2.0])
+
+        result = waveform.waveform(t, dt)
+
+        np.testing.assert_array_equal(result, np.zeros_like(t))
+
+
+class TestAudioFileWaveformLoop:
+    """Tests for loop functionality."""
+
+    def test_loop_wraps_around(self, tmp_path):
+        """Test that loop=True wraps audio around."""
+        sr = 44100
+        duration = 0.1
+        n_samples = int(sr * duration)
+        # Create distinctive pattern
+        data = np.linspace(-1, 1, n_samples).astype(np.float32)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath, loop=True)
+
+        dt = 1.0 / sr  # Use native sample rate for simplicity
+
+        # Get value at t=0
+        t0 = np.array([0.0])
+        val0 = waveform.waveform(t0, dt)[0]
+
+        # Get value at t=duration (should wrap to start)
+        t1 = np.array([duration])
+        val1 = waveform.waveform(t1, dt)[0]
+
+        # Should be approximately equal (same position after wrap)
+        assert abs(val0 - val1) < 0.01
+
+    def test_no_loop_stops_at_end(self, tmp_path):
+        """Test that loop=False returns zero past end."""
+        sr = 44100
+        duration = 0.1
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath, loop=False)
+
+        dt = 1e-5
+        t = np.array([duration + 0.01])  # Past end
+
+        result = waveform.waveform(t, dt)
+
+        assert result[0] == 0.0
+
+
+class TestAudioFileWaveformProperties:
+    """Tests for property accessors."""
+
+    def test_duration_seconds(self, tmp_path):
+        """Test duration_seconds property."""
+        sr = 44100
+        duration = 0.5
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath)
+
+        assert abs(waveform.duration_seconds - duration) < 0.001
+
+    def test_native_sample_rate(self, tmp_path):
+        """Test native_sample_rate property."""
+        sr = 48000
+        duration = 0.1
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath)
+
+        assert waveform.native_sample_rate == sr
+
+    def test_num_samples(self, tmp_path):
+        """Test num_samples property."""
+        sr = 44100
+        duration = 0.1
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath)
+
+        assert waveform.num_samples == n_samples
+
+
+class TestAudioFileWaveformIntegration:
+    """Integration tests with other strata_fdtd components."""
+
+    def test_with_circular_membrane_source(self, tmp_path):
+        """Test AudioFileWaveform works with CircularMembraneSource."""
+        from strata_fdtd import CircularMembraneSource
+
+        sr = 44100
+        duration = 0.01
+        n_samples = int(sr * duration)
+        data = (np.sin(2 * np.pi * 440 * np.linspace(0, duration, n_samples)) * 32767).astype(np.int16)
+
+        filepath = tmp_path / "test.wav"
+        wavfile.write(filepath, sr, data)
+
+        waveform = AudioFileWaveform(filepath)
+
+        # Should be usable as waveform for CircularMembraneSource
+        source = CircularMembraneSource(
+            center=(0.1, 0.01, 0.15),
+            radius=0.1,
+            normal_axis='y',
+            waveform=waveform,
+        )
+
+        assert source.waveform is waveform
+
+    def test_import_from_top_level(self):
+        """Test AudioFileWaveform can be imported from strata_fdtd."""
+        from strata_fdtd import AudioFileWaveform as AWF
+
+        assert AWF is AudioFileWaveform


### PR DESCRIPTION
## Summary

Implement `AudioFileWaveform` that loads audio files (WAV, MP3, FLAC) and provides them as source waveforms for FDTD simulation. This enables the ultimate goal of playing a song through a simulated speaker cabinet and recording the output.

## Features

- Load WAV files natively via scipy.io.wavfile
- Optional support for MP3/FLAC via soundfile package
- Automatic resampling to simulation timestep with result caching
- Stereo to mono conversion (mix or select specific channel)
- Start time and duration trimming
- Loop option for repeating audio
- Compatible with `GaussianPulse` interface (`.waveform(t, dt)` method)

## Example Usage

```python
from strata_fdtd import (
    LoudspeakerEnclosure, AudioFileWaveform,
    UniformGrid, FDTDSolver, PML, Microphone
)

# Load test audio
audio = AudioFileWaveform("reference_track.wav", amplitude=0.5, duration=1.0)

# Build sealed subwoofer
enc = LoudspeakerEnclosure(external_size=(0.3, 0.35, 0.4))
enc.add_driver(
    (0.15, 0.25),
    diameter=0.25,  # 10" woofer
    baffle_face="front",
    waveform=audio,
)

# Set up simulation
grid = UniformGrid(shape=(150, 175, 200), resolution=2e-3)
solver = FDTDSolver(grid)
solver.set_geometry(enc.build())

for source in enc.get_membrane_sources():
    solver.add_source(source)

# Run simulation for audio duration
n_steps = int(audio.duration_seconds / solver.dt)
for _ in range(n_steps):
    solver.step()
```

## Test Plan

- [x] Load WAV (16-bit, 32-bit float)
- [x] Load stereo, convert to mono (mix or select channel)
- [x] Handle missing files gracefully
- [x] Start time and duration trimming
- [x] Resampling to simulation timestep
- [x] Frequency content preserved after resampling
- [x] Loop functionality
- [x] Amplitude scaling
- [x] Compatible with CircularMembraneSource
- [x] All 24 tests pass

## Files Changed

- `src/strata_fdtd/core/waveforms.py` (new) - AudioFileWaveform class
- `src/strata_fdtd/core/__init__.py` - Export new class
- `src/strata_fdtd/__init__.py` - Top-level export
- `tests/test_waveforms.py` (new) - 24 comprehensive tests

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)