### PR TITLE
Add 2D slice visualization mode for cross-section viewing

### DIFF
--- a/strata-ui/src/components/visualization/SliceControlPanel.tsx
+++ b/strata-ui/src/components/visualization/SliceControlPanel.tsx
@@ -1,0 +1,110 @@
+/**
+ * SliceControlPanel - UI controls for configuring 2D slice visualization.
+ *
+ * Provides axis selection and slice position controls.
+ */
+
+import { useMemo } from "react";
+import { Panel } from "./Layout";
+import { Badge } from "../ui/badge";
+import { Slider } from "../ui/slider";
+import { getSliceIndex, getAxisSize, getSlicePlaneLabel } from "../../lib/sliceUtils";
+import type { SliceAxis } from "../../stores/simulationStore";
+
+export interface SliceControlPanelProps {
+  /** Currently selected axis */
+  axis: SliceAxis;
+  /** Current position (0-1 normalized) */
+  position: number;
+  /** Grid dimensions [nx, ny, nz] */
+  shape: [number, number, number];
+  /** Grid resolution in meters */
+  resolution: number;
+  /** Callback when axis changes */
+  onAxisChange: (axis: SliceAxis) => void;
+  /** Callback when position changes */
+  onPositionChange: (position: number) => void;
+}
+
+const AXIS_OPTIONS: { value: SliceAxis; label: string; description: string }[] = [
+  { value: "x", label: "X", description: "YZ plane" },
+  { value: "y", label: "Y", description: "XZ plane" },
+  { value: "z", label: "Z", description: "XY plane" },
+];
+
+export function SliceControlPanel({
+  axis,
+  position,
+  shape,
+  resolution,
+  onAxisChange,
+  onPositionChange,
+}: SliceControlPanelProps) {
+  // Memoize slider value to prevent infinite re-render loops
+  const sliderValue = useMemo(() => [position * 100], [position]);
+
+  // Calculate current slice info
+  const axisSize = getAxisSize(shape, axis);
+  const sliceIndex = getSliceIndex(position, axisSize);
+  const physicalPosition = sliceIndex * resolution;
+
+  return (
+    <Panel title="Slice View">
+      <div className="space-y-4">
+        {/* Axis selector */}
+        <div>
+          <div className="text-xs text-muted-foreground mb-2">
+            Slice Axis
+          </div>
+          <div className="flex gap-1">
+            {AXIS_OPTIONS.map((opt) => (
+              <Badge
+                key={opt.value}
+                variant={axis === opt.value ? "default" : "secondary"}
+                className="cursor-pointer flex-1 justify-center"
+                onClick={() => onAxisChange(opt.value)}
+                title={opt.description}
+              >
+                {opt.label}
+              </Badge>
+            ))}
+          </div>
+          <div className="text-xs text-muted-foreground mt-1">
+            {getSlicePlaneLabel(axis)}
+          </div>
+        </div>
+
+        {/* Position slider */}
+        <div>
+          <div className="flex justify-between text-xs text-muted-foreground mb-2">
+            <span>Position</span>
+            <span>{(position * 100).toFixed(0)}%</span>
+          </div>
+          <Slider
+            value={sliderValue}
+            min={0}
+            max={100}
+            step={1}
+            onValueChange={([v]) => onPositionChange(v / 100)}
+          />
+        </div>
+
+        {/* Current slice info */}
+        <div className="p-2 bg-secondary/30 rounded-md space-y-1 text-xs">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Slice index</span>
+            <span>{sliceIndex} / {axisSize - 1}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Position</span>
+            <span>{(physicalPosition * 100).toFixed(1)} cm</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">{axis.toUpperCase()} range</span>
+            <span>0 - {((axisSize - 1) * resolution * 100).toFixed(1)} cm</span>
+          </div>
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/strata-ui/src/components/visualization/SliceRenderer.tsx
+++ b/strata-ui/src/components/visualization/SliceRenderer.tsx
@@ -1,0 +1,242 @@
+/**
+ * SliceRenderer - 2D heatmap visualization of pressure field slices.
+ *
+ * Renders a 2D cross-section of the 3D pressure field using Canvas 2D API.
+ * Supports real-time updates during playback with efficient pixel manipulation.
+ */
+
+import { useRef, useEffect, useCallback, forwardRef, useImperativeHandle } from "react";
+import * as THREE from "three";
+import { extractSlice, getSliceIndex, getAxisSize, getSlicePlaneLabel } from "../../lib/sliceUtils";
+import { applyPressureColormap, getSymmetricRange } from "../../lib/colormap";
+import type { SliceAxis } from "../../stores/simulationStore";
+
+export interface SliceRendererProps {
+  /** 3D pressure field data */
+  pressure: Float32Array | null;
+  /** Grid dimensions [nx, ny, nz] */
+  shape: [number, number, number];
+  /** Grid resolution in meters */
+  resolution: number;
+  /** Axis perpendicular to the slice plane */
+  axis: SliceAxis;
+  /** Position along the axis (0-1 normalized) */
+  position: number;
+  /** Whether to show axis labels */
+  showLabels?: boolean;
+  /** Whether to show the colorbar */
+  showColorbar?: boolean;
+}
+
+export interface SliceRendererHandle {
+  /** Get the canvas element for export */
+  getCanvas: () => HTMLCanvasElement | null;
+  /** Force a render update */
+  render: () => void;
+}
+
+// Pre-allocated color for performance
+const tempColor = new THREE.Color();
+
+export const SliceRenderer = forwardRef<SliceRendererHandle, SliceRendererProps>(
+  function SliceRenderer(
+    {
+      pressure,
+      shape,
+      resolution,
+      axis,
+      position,
+      showLabels = true,
+      showColorbar = true,
+    },
+    ref
+  ) {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const colorbarCanvasRef = useRef<HTMLCanvasElement>(null);
+
+    // Expose methods via ref
+    useImperativeHandle(ref, () => ({
+      getCanvas: () => canvasRef.current,
+      render: () => renderSlice(),
+    }));
+
+    // Calculate slice info
+    const axisSize = getAxisSize(shape, axis);
+    const sliceIndex = getSliceIndex(position, axisSize);
+    const physicalPosition = sliceIndex * resolution;
+
+    // Render the slice to canvas
+    const renderSlice = useCallback(() => {
+      if (!canvasRef.current || !pressure || pressure.length === 0) {
+        return;
+      }
+
+      const canvas = canvasRef.current;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+
+      // Extract 2D slice from 3D data
+      const slice = extractSlice(pressure, shape, axis, position, resolution);
+
+      // Resize canvas to match slice dimensions
+      // Use a reasonable display size while maintaining aspect ratio
+      const maxDisplaySize = 800;
+      const aspectRatio = slice.width / slice.height;
+      let displayWidth: number;
+      let displayHeight: number;
+
+      if (aspectRatio >= 1) {
+        displayWidth = Math.min(maxDisplaySize, slice.width * 4);
+        displayHeight = displayWidth / aspectRatio;
+      } else {
+        displayHeight = Math.min(maxDisplaySize, slice.height * 4);
+        displayWidth = displayHeight * aspectRatio;
+      }
+
+      canvas.width = slice.width;
+      canvas.height = slice.height;
+      canvas.style.width = `${displayWidth}px`;
+      canvas.style.height = `${displayHeight}px`;
+
+      // Get pressure range for color mapping (symmetric around zero)
+      const [min, max] = getSymmetricRange(slice.data);
+
+      // Create image data for pixel manipulation
+      const imageData = ctx.createImageData(slice.width, slice.height);
+      const pixels = imageData.data;
+
+      // Apply colormap to each pixel
+      for (let i = 0; i < slice.data.length; i++) {
+        const value = slice.data[i];
+        applyPressureColormap(value, min, max, tempColor);
+
+        // Note: Canvas Y is inverted (0 at top), so we flip vertically
+        const row = Math.floor(i / slice.width);
+        const col = i % slice.width;
+        const flippedRow = slice.height - 1 - row;
+        const pixelIndex = (flippedRow * slice.width + col) * 4;
+
+        pixels[pixelIndex] = Math.round(tempColor.r * 255);
+        pixels[pixelIndex + 1] = Math.round(tempColor.g * 255);
+        pixels[pixelIndex + 2] = Math.round(tempColor.b * 255);
+        pixels[pixelIndex + 3] = 255;
+      }
+
+      // Draw to canvas
+      ctx.putImageData(imageData, 0, 0);
+
+      // Render colorbar if enabled
+      if (showColorbar && colorbarCanvasRef.current) {
+        renderColorbar(min, max);
+      }
+    }, [pressure, shape, axis, position, resolution, showColorbar]);
+
+    // Render the colorbar
+    const renderColorbar = useCallback((min: number, max: number) => {
+      const canvas = colorbarCanvasRef.current;
+      if (!canvas) return;
+
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return;
+
+      const width = 20;
+      const height = 200;
+      canvas.width = width;
+      canvas.height = height;
+
+      // Create gradient from blue (bottom) to white (middle) to red (top)
+      const imageData = ctx.createImageData(width, height);
+      const pixels = imageData.data;
+
+      for (let y = 0; y < height; y++) {
+        // Map y to value: bottom = min, top = max
+        const t = 1 - y / (height - 1);
+        const value = min + t * (max - min);
+        applyPressureColormap(value, min, max, tempColor);
+
+        for (let x = 0; x < width; x++) {
+          const idx = (y * width + x) * 4;
+          pixels[idx] = Math.round(tempColor.r * 255);
+          pixels[idx + 1] = Math.round(tempColor.g * 255);
+          pixels[idx + 2] = Math.round(tempColor.b * 255);
+          pixels[idx + 3] = 255;
+        }
+      }
+
+      ctx.putImageData(imageData, 0, 0);
+    }, []);
+
+    // Re-render when dependencies change
+    useEffect(() => {
+      renderSlice();
+    }, [renderSlice]);
+
+    // Format pressure value for display
+    const formatPressure = (value: number): string => {
+      if (Math.abs(value) < 0.001) {
+        return value.toExponential(1);
+      }
+      return value.toFixed(3);
+    };
+
+    // Get pressure range for colorbar labels
+    const pressureRange = pressure ? getSymmetricRange(pressure) : [0, 0];
+
+    return (
+      <div
+        ref={containerRef}
+        className="w-full h-full flex items-center justify-center bg-background p-4"
+      >
+        <div className="flex items-center gap-4">
+          {/* Main slice visualization */}
+          <div className="relative">
+            <canvas
+              ref={canvasRef}
+              className="border border-border rounded shadow-md"
+              style={{ imageRendering: "pixelated" }}
+            />
+
+            {/* Axis labels */}
+            {showLabels && pressure && (
+              <>
+                {/* Slice info overlay */}
+                <div className="absolute top-2 left-2 bg-background/80 px-2 py-1 rounded text-xs">
+                  <div className="font-medium">{getSlicePlaneLabel(axis)}</div>
+                  <div className="text-muted-foreground">
+                    {axis.toUpperCase()} = {(physicalPosition * 100).toFixed(1)} cm
+                    <span className="text-muted-foreground/60"> (index {sliceIndex}/{axisSize - 1})</span>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+
+          {/* Colorbar */}
+          {showColorbar && pressure && (
+            <div className="flex flex-col items-center">
+              <div className="text-xs text-muted-foreground mb-1">
+                {formatPressure(pressureRange[1])} Pa
+              </div>
+              <canvas
+                ref={colorbarCanvasRef}
+                className="border border-border rounded"
+                style={{ width: "20px", height: "200px" }}
+              />
+              <div className="text-xs text-muted-foreground mt-1">
+                {formatPressure(pressureRange[0])} Pa
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Empty state */}
+        {!pressure && (
+          <div className="text-muted-foreground text-sm">
+            No pressure data available
+          </div>
+        )}
+      </div>
+    );
+  }
+);

--- a/strata-ui/src/components/visualization/ViewModePanel.tsx
+++ b/strata-ui/src/components/visualization/ViewModePanel.tsx
@@ -1,0 +1,61 @@
+/**
+ * ViewModePanel - Toggle between 3D voxel and 2D slice visualization modes.
+ */
+
+import { Panel } from "./Layout";
+import { Badge } from "../ui/badge";
+import { Box, Layers } from "lucide-react";
+import type { ViewMode } from "../../stores/simulationStore";
+
+export interface ViewModePanelProps {
+  /** Current view mode */
+  mode: ViewMode;
+  /** Callback when mode changes */
+  onModeChange: (mode: ViewMode) => void;
+}
+
+const VIEW_MODES: {
+  value: ViewMode;
+  label: string;
+  icon: React.ReactNode;
+  description: string;
+}[] = [
+  {
+    value: "3d",
+    label: "3D",
+    icon: <Box className="h-3 w-3" />,
+    description: "3D voxel visualization",
+  },
+  {
+    value: "slice",
+    label: "Slice",
+    icon: <Layers className="h-3 w-3" />,
+    description: "2D cross-section view",
+  },
+];
+
+export function ViewModePanel({ mode, onModeChange }: ViewModePanelProps) {
+  return (
+    <Panel title="View Mode">
+      <div className="flex gap-1">
+        {VIEW_MODES.map((opt) => (
+          <Badge
+            key={opt.value}
+            variant={mode === opt.value ? "default" : "secondary"}
+            className="cursor-pointer flex items-center gap-1 flex-1 justify-center"
+            onClick={() => onModeChange(opt.value)}
+            title={opt.description}
+          >
+            {opt.icon}
+            {opt.label}
+          </Badge>
+        ))}
+      </div>
+      <p className="text-xs text-muted-foreground mt-2">
+        {mode === "3d"
+          ? "Viewing 3D pressure voxels"
+          : "Viewing 2D pressure slice"}
+      </p>
+    </Panel>
+  );
+}

--- a/strata-ui/src/index.ts
+++ b/strata-ui/src/index.ts
@@ -71,6 +71,12 @@ export { TimeSeriesPlot } from './components/visualization/TimeSeriesPlot'
 export { VisualizationModePanel } from './components/visualization/VisualizationModePanel'
 export { VoxelRenderer } from './components/visualization/VoxelRenderer'
 export { WaterfallPlot } from './components/visualization/WaterfallPlot'
+export { SliceRenderer } from './components/visualization/SliceRenderer'
+export type { SliceRendererHandle, SliceRendererProps } from './components/visualization/SliceRenderer'
+export { SliceControlPanel } from './components/visualization/SliceControlPanel'
+export type { SliceControlPanelProps } from './components/visualization/SliceControlPanel'
+export { ViewModePanel } from './components/visualization/ViewModePanel'
+export type { ViewModePanelProps } from './components/visualization/ViewModePanel'
 
 // =============================================================================
 // Hooks
@@ -104,6 +110,8 @@ export type {
   DownsampleMethod,
   VisualizationMode,
   FlowParticleConfig,
+  ViewMode,
+  SliceAxis,
 } from './stores/simulationStore'
 
 // =============================================================================
@@ -141,6 +149,9 @@ export * from './lib/export'
 
 // Performance
 export * from './lib/performance'
+
+// Slice utilities
+export * from './lib/sliceUtils'
 
 // Demo geometry
 export * from './lib/demoGeometry'

--- a/strata-ui/src/lib/sliceUtils.ts
+++ b/strata-ui/src/lib/sliceUtils.ts
@@ -1,0 +1,178 @@
+/**
+ * Utilities for extracting 2D slices from 3D pressure field data.
+ */
+
+import type { SliceAxis } from "../stores/simulationStore";
+
+/**
+ * Result of slice extraction
+ */
+export interface SliceData {
+  /** 2D pressure data for the slice */
+  data: Float32Array;
+  /** Width of the slice in cells */
+  width: number;
+  /** Height of the slice in cells */
+  height: number;
+  /** Physical width in meters */
+  physicalWidth: number;
+  /** Physical height in meters */
+  physicalHeight: number;
+  /** Axis labels for the slice dimensions */
+  axisLabels: [string, string];
+}
+
+/**
+ * Extract a 2D slice from a 3D pressure field.
+ *
+ * The 3D data is assumed to be in row-major order with the indexing:
+ * index = x + y * nx + z * nx * ny
+ *
+ * @param data - 3D pressure field as flat Float32Array
+ * @param shape - Grid dimensions [nx, ny, nz]
+ * @param axis - Axis perpendicular to the slice plane ('x', 'y', or 'z')
+ * @param normalizedPosition - Position along the axis (0-1)
+ * @param resolution - Grid resolution in meters
+ * @returns SliceData containing the 2D slice
+ */
+export function extractSlice(
+  data: Float32Array,
+  shape: [number, number, number],
+  axis: SliceAxis,
+  normalizedPosition: number,
+  resolution: number
+): SliceData {
+  const [nx, ny, nz] = shape;
+
+  // Clamp position to valid range
+  const clampedPosition = Math.max(0, Math.min(1, normalizedPosition));
+
+  if (axis === "z") {
+    // XY plane at constant Z (top-down view)
+    const zIndex = Math.min(
+      nz - 1,
+      Math.max(0, Math.round(clampedPosition * (nz - 1)))
+    );
+    const sliceData = new Float32Array(nx * ny);
+
+    for (let y = 0; y < ny; y++) {
+      for (let x = 0; x < nx; x++) {
+        const idx3d = x + y * nx + zIndex * nx * ny;
+        sliceData[x + y * nx] = data[idx3d];
+      }
+    }
+
+    return {
+      data: sliceData,
+      width: nx,
+      height: ny,
+      physicalWidth: nx * resolution,
+      physicalHeight: ny * resolution,
+      axisLabels: ["X", "Y"],
+    };
+  } else if (axis === "y") {
+    // XZ plane at constant Y (front/back view)
+    const yIndex = Math.min(
+      ny - 1,
+      Math.max(0, Math.round(clampedPosition * (ny - 1)))
+    );
+    const sliceData = new Float32Array(nx * nz);
+
+    for (let z = 0; z < nz; z++) {
+      for (let x = 0; x < nx; x++) {
+        const idx3d = x + yIndex * nx + z * nx * ny;
+        // Store with Z as height (row), X as width (column)
+        sliceData[x + z * nx] = data[idx3d];
+      }
+    }
+
+    return {
+      data: sliceData,
+      width: nx,
+      height: nz,
+      physicalWidth: nx * resolution,
+      physicalHeight: nz * resolution,
+      axisLabels: ["X", "Z"],
+    };
+  } else {
+    // YZ plane at constant X (left/right view)
+    const xIndex = Math.min(
+      nx - 1,
+      Math.max(0, Math.round(clampedPosition * (nx - 1)))
+    );
+    const sliceData = new Float32Array(ny * nz);
+
+    for (let z = 0; z < nz; z++) {
+      for (let y = 0; y < ny; y++) {
+        const idx3d = xIndex + y * nx + z * nx * ny;
+        // Store with Z as height (row), Y as width (column)
+        sliceData[y + z * ny] = data[idx3d];
+      }
+    }
+
+    return {
+      data: sliceData,
+      width: ny,
+      height: nz,
+      physicalWidth: ny * resolution,
+      physicalHeight: nz * resolution,
+      axisLabels: ["Y", "Z"],
+    };
+  }
+}
+
+/**
+ * Calculate the slice index from a normalized position.
+ *
+ * @param normalizedPosition - Position along axis (0-1)
+ * @param axisSize - Number of cells along the axis
+ * @returns The integer slice index
+ */
+export function getSliceIndex(
+  normalizedPosition: number,
+  axisSize: number
+): number {
+  return Math.min(
+    axisSize - 1,
+    Math.max(0, Math.round(normalizedPosition * (axisSize - 1)))
+  );
+}
+
+/**
+ * Get the size of a dimension based on the slice axis.
+ *
+ * @param shape - Grid dimensions [nx, ny, nz]
+ * @param axis - The axis perpendicular to the slice
+ * @returns The number of cells along that axis
+ */
+export function getAxisSize(
+  shape: [number, number, number],
+  axis: SliceAxis
+): number {
+  const [nx, ny, nz] = shape;
+  switch (axis) {
+    case "x":
+      return nx;
+    case "y":
+      return ny;
+    case "z":
+      return nz;
+  }
+}
+
+/**
+ * Get a human-readable label for the slice plane.
+ *
+ * @param axis - The axis perpendicular to the slice
+ * @returns Description of the slice plane (e.g., "XY plane (Z slice)")
+ */
+export function getSlicePlaneLabel(axis: SliceAxis): string {
+  switch (axis) {
+    case "x":
+      return "YZ plane (X slice)";
+    case "y":
+      return "XZ plane (Y slice)";
+    case "z":
+      return "XY plane (Z slice)";
+  }
+}

--- a/strata-ui/src/stores/simulationStore.ts
+++ b/strata-ui/src/stores/simulationStore.ts
@@ -43,6 +43,12 @@ export type DownsampleMethod = "nearest" | "average" | "max";
 /** Visualization mode */
 export type VisualizationMode = "voxels" | "flow_particles";
 
+/** View mode - 3D voxels or 2D slice */
+export type ViewMode = "3d" | "slice";
+
+/** Slice axis */
+export type SliceAxis = "x" | "y" | "z";
+
 /** Flow particle configuration */
 export interface FlowParticleConfig {
   /** Number of particles to render */
@@ -97,6 +103,11 @@ export interface SimulationState {
   // Selection
   selectedProbes: string[];
   hoveredVoxel: [number, number, number] | null;
+
+  // Slice view
+  viewMode: ViewMode;
+  sliceAxis: SliceAxis;
+  slicePosition: number; // 0-1 normalized position along axis
 
   // Loading state
   isLoading: boolean;
@@ -156,6 +167,11 @@ export interface SimulationActions {
   toggleProbe: (name: string) => void;
   setSelectedProbes: (names: string[]) => void;
   setHoveredVoxel: (coords: [number, number, number] | null) => void;
+
+  // Slice view
+  setViewMode: (mode: ViewMode) => void;
+  setSliceAxis: (axis: SliceAxis) => void;
+  setSlicePosition: (position: number) => void;
 
   // Performance
   setEnableDownsampling: (enable: boolean) => void;
@@ -226,6 +242,11 @@ const DEFAULT_STATE: SimulationState = {
   // Selection
   selectedProbes: [],
   hoveredVoxel: null,
+
+  // Slice view
+  viewMode: "3d",
+  sliceAxis: "y",
+  slicePosition: 0.5,
 
   // Loading
   isLoading: false,
@@ -616,6 +637,17 @@ export const useSimulationStore = create<SimulationStore>()(
       set({ hoveredVoxel: coords }),
 
     // =========================================================================
+    // Slice View
+    // =========================================================================
+
+    setViewMode: (mode: ViewMode) => set({ viewMode: mode }),
+
+    setSliceAxis: (axis: SliceAxis) => set({ sliceAxis: axis }),
+
+    setSlicePosition: (position: number) =>
+      set({ slicePosition: Math.max(0, Math.min(1, position)) }),
+
+    // =========================================================================
     // Performance
     // =========================================================================
 
@@ -887,6 +919,9 @@ export const selectTargetVoxels = (state: SimulationStore) => state.targetVoxels
 export const selectDownsampleMethod = (state: SimulationStore) => state.downsampleMethod;
 export const selectShowPerformanceMetrics = (state: SimulationStore) => state.showPerformanceMetrics;
 export const selectPerformanceMetrics = (state: SimulationStore) => state.performanceMetrics;
+export const selectViewMode = (state: SimulationStore) => state.viewMode;
+export const selectSliceAxis = (state: SimulationStore) => state.sliceAxis;
+export const selectSlicePosition = (state: SimulationStore) => state.slicePosition;
 
 /** @deprecated Use individual selectors with useSimulationStore instead */
 export const usePlaybackState = () =>


### PR DESCRIPTION
## Summary

- Adds 2D cross-section slice visualization mode to the viewer
- Users can toggle between 3D voxel view and 2D slice view
- Slice controls allow selecting axis (X, Y, Z) and position along the axis
- Efficient Canvas 2D rendering with diverging colormap (blue-white-red)

## Changes

### New Components
- `SliceRenderer` - Canvas 2D-based 2D heatmap visualization with colorbar
- `SliceControlPanel` - Axis selection and position slider controls  
- `ViewModePanel` - Toggle between 3D and Slice view modes

### New Utilities
- `sliceUtils.ts` - Slice extraction from 3D Float32Array pressure data

### Store Changes
- Added `viewMode`, `sliceAxis`, `slicePosition` state to simulationStore
- Added corresponding actions and selectors

### ViewerPage Integration
- Conditional rendering of SliceRenderer or OptimizedVoxelRenderer based on view mode
- Export functionality works for both view modes

## Test plan

- [ ] Load a simulation with pressure data
- [ ] Toggle between 3D and Slice view modes
- [ ] Verify slice renders correctly for each axis (X, Y, Z)
- [ ] Verify position slider updates slice position
- [ ] Verify colorbar displays correct pressure range
- [ ] Verify playback works in slice mode
- [ ] Verify export works in slice mode

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)