### PR TITLE
Enhanced spectral analysis: source waveforms, transfer functions

### DIFF
--- a/strata-ui/src/components/visualization/ProbesPanel.tsx
+++ b/strata-ui/src/components/visualization/ProbesPanel.tsx
@@ -1,0 +1,141 @@
+import { useMemo } from "react";
+import { Eye, EyeOff, MapPin } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+// d3.schemeCategory10 colors for consistent probe coloring
+const PROBE_COLORS = [
+  "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728", "#9467bd",
+  "#8c564b", "#e377c2", "#7f7f7f", "#bcbd22", "#17becf",
+];
+
+export interface Probe {
+  name: string;
+  position: [number, number, number];
+}
+
+export interface ProbesPanelProps {
+  probes: Probe[];
+  hiddenProbes: string[];
+  showProbeMarkers: boolean;
+  onToggleProbe: (name: string) => void;
+  onShowAll: () => void;
+  onHideAll: () => void;
+  onToggleMarkers: (show: boolean) => void;
+}
+
+export function ProbesPanel({
+  probes,
+  hiddenProbes,
+  showProbeMarkers,
+  onToggleProbe,
+  onShowAll,
+  onHideAll,
+  onToggleMarkers,
+}: ProbesPanelProps) {
+  const probeColors = useMemo(
+    () => new Map(probes.map((probe, i) => [probe.name, PROBE_COLORS[i % PROBE_COLORS.length]])),
+    [probes]
+  );
+
+  const hiddenSet = useMemo(() => new Set(hiddenProbes), [hiddenProbes]);
+  const visibleCount = probes.length - hiddenSet.size;
+
+  if (probes.length === 0) {
+    return (
+      <div className="text-xs text-muted-foreground italic">
+        No probes in simulation
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Header with show/hide all buttons */}
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-muted-foreground">
+          {visibleCount}/{probes.length} visible
+        </span>
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs"
+            onClick={onShowAll}
+            disabled={visibleCount === probes.length}
+          >
+            Show All
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs"
+            onClick={onHideAll}
+            disabled={visibleCount === 0}
+          >
+            Hide All
+          </Button>
+        </div>
+      </div>
+
+      {/* Probe list */}
+      <div className="space-y-1">
+        {probes.map((probe) => {
+          const isVisible = !hiddenSet.has(probe.name);
+          const color = probeColors.get(probe.name);
+
+          return (
+            <button
+              key={probe.name}
+              onClick={() => onToggleProbe(probe.name)}
+              className={`
+                w-full flex items-center gap-2 px-2 py-1.5 rounded-md text-left
+                transition-colors cursor-pointer
+                ${isVisible
+                  ? "bg-secondary/50 hover:bg-secondary"
+                  : "opacity-50 hover:bg-secondary/30"
+                }
+              `}
+            >
+              {/* Color indicator */}
+              <div
+                className="w-3 h-3 rounded-full flex-shrink-0"
+                style={{ backgroundColor: color }}
+              />
+
+              {/* Probe name */}
+              <span className="flex-1 text-sm truncate">
+                {probe.name}
+              </span>
+
+              {/* Position (small) */}
+              <span className="text-[10px] text-muted-foreground hidden sm:block">
+                ({probe.position[0].toFixed(2)}, {probe.position[1].toFixed(2)}, {probe.position[2].toFixed(2)})
+              </span>
+
+              {/* Visibility icon */}
+              {isVisible ? (
+                <Eye className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+              ) : (
+                <EyeOff className="h-3.5 w-3.5 text-muted-foreground flex-shrink-0" />
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 3D Markers toggle */}
+      <div className="pt-2 border-t border-border">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={showProbeMarkers}
+            onChange={(e) => onToggleMarkers(e.target.checked)}
+            className="rounded"
+          />
+          <MapPin className="h-3.5 w-3.5" />
+          Show 3D Markers
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/strata-ui/src/components/visualization/SourcesPanel.tsx
+++ b/strata-ui/src/components/visualization/SourcesPanel.tsx
@@ -1,0 +1,76 @@
+import { MapPin } from "lucide-react";
+import type { SourceData } from "@/stores/simulationStore";
+
+export interface SourcesPanelProps {
+  sources: SourceData[];
+  showSourceMarkers: boolean;
+  onToggleMarkers: (show: boolean) => void;
+}
+
+// Format frequency for display
+function formatFrequency(freq: number): string {
+  if (freq >= 1000) {
+    return `${(freq / 1000).toFixed(1)} kHz`;
+  }
+  return `${freq.toFixed(0)} Hz`;
+}
+
+export function SourcesPanel({
+  sources,
+  showSourceMarkers,
+  onToggleMarkers,
+}: SourcesPanelProps) {
+  if (sources.length === 0) {
+    return (
+      <div className="text-xs text-muted-foreground italic">
+        No sources in simulation
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Source list */}
+      <div className="space-y-1">
+        {sources.map((source) => (
+          <div
+            key={source.name}
+            className="flex items-center gap-2 px-2 py-1.5 rounded-md bg-secondary/50 text-sm"
+          >
+            {/* Source type icon/indicator */}
+            <div className="w-3 h-3 rounded-full bg-yellow-500 flex-shrink-0" />
+
+            {/* Source info */}
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-medium truncate">{source.type}</span>
+                {source.frequency && (
+                  <span className="text-xs text-muted-foreground">
+                    {formatFrequency(source.frequency)}
+                  </span>
+                )}
+              </div>
+              <div className="text-[10px] text-muted-foreground">
+                ({source.position[0].toFixed(3)}, {source.position[1].toFixed(3)}, {source.position[2].toFixed(3)})
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* 3D Markers toggle */}
+      <div className="pt-2 border-t border-border">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={showSourceMarkers}
+            onChange={(e) => onToggleMarkers(e.target.checked)}
+            className="rounded"
+          />
+          <MapPin className="h-3.5 w-3.5" />
+          Show 3D Markers
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/strata-ui/src/index.ts
+++ b/strata-ui/src/index.ts
@@ -58,15 +58,19 @@ export { FlowParticleRenderer } from './components/visualization/FlowParticleRen
 export * from './components/visualization/GeometryOverlay'
 export { Layout, Panel } from './components/visualization/Layout'
 export { OptimizedVoxelRenderer } from './components/visualization/OptimizedVoxelRenderer'
-export type { VoxelRendererHandle, OptimizedVoxelRendererProps } from './components/visualization/OptimizedVoxelRenderer'
+export type { VoxelRendererHandle, OptimizedVoxelRendererProps, ProbeMarkerData, SourceMarkerData } from './components/visualization/OptimizedVoxelRenderer'
 export { PerformanceMetrics } from './components/visualization/PerformanceMetrics'
 export { PlaybackControls } from './components/visualization/PlaybackControls'
+export { ProbesPanel } from './components/visualization/ProbesPanel'
+export { SourcesPanel } from './components/visualization/SourcesPanel'
 export { ViewerHelpModal } from './components/visualization/ViewerHelpModal'
 export { BuilderHelpModal } from './components/visualization/BuilderHelpModal'
 export { Spectrogram } from './components/visualization/Spectrogram'
 export { SpectrumPlot } from './components/visualization/SpectrumPlot'
+export type { SpectrumMode } from './components/visualization/SpectrumPlot'
 export { ThreeViewer } from './components/visualization/ThreeViewer'
 export { TimeSeriesPlot } from './components/visualization/TimeSeriesPlot'
+export type { SourceTimeSeries } from './components/visualization/TimeSeriesPlot'
 // VideoExportButton moved to strata-web (requires useVideoExport/FFmpeg)
 export { VisualizationModePanel } from './components/visualization/VisualizationModePanel'
 export { VoxelRenderer } from './components/visualization/VoxelRenderer'
@@ -94,6 +98,8 @@ export {
   useGridInfo,
   useLoadingState,
   useProbeData,
+  useProbeVisibility,
+  useSourceData,
   usePerformanceSettings,
   useBackgroundLoadingState,
 } from './stores/simulationStore'
@@ -104,6 +110,7 @@ export type {
   DownsampleMethod,
   VisualizationMode,
   FlowParticleConfig,
+  SourceData,
 } from './stores/simulationStore'
 
 // =============================================================================

--- a/strata-web/src/hooks/useHDF5Simulation.ts
+++ b/strata-web/src/hooks/useHDF5Simulation.ts
@@ -93,6 +93,17 @@ export function useHDF5Simulation(): UseHDF5SimulationResult {
       // Convert to SimulationMetadata
       const metadata = toSimulationMetadata(data);
 
+      // Convert sources to SourceData format
+      const sources = data.sources.map((source, index) => ({
+        name: `source_${index}`,
+        type: source.type,
+        position: source.position,
+        frequency: source.frequency,
+        bandwidth: source.bandwidth,
+        amplitude: source.amplitude,
+        waveform: source.waveform,
+      }));
+
       // Set initial state
       store.manifest = manifest;
       store.metadata = metadata;
@@ -102,6 +113,7 @@ export function useHDF5Simulation(): UseHDF5SimulationResult {
       store.probeData = data.probes;
       store.geometry = data.geometry;
       store.selectedProbes = Object.keys(data.probes.probes);
+      store.sources = sources;
       store.currentFrame = 0;
       store.isLoading = false;
       store.error = null;

--- a/strata-web/src/index.css
+++ b/strata-web/src/index.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+/* Include strata-ui component library source files for Tailwind class scanning */
+@source "../node_modules/@strata/ui/src/**/*.tsx";
+@source "../node_modules/@strata/ui/src/**/*.ts";
+
 @theme {
   /* shadcn/ui CSS variables for dark theme */
   --color-background: hsl(222.2 84% 4.9%);

--- a/strata-web/src/pages/ViewerPage.tsx
+++ b/strata-web/src/pages/ViewerPage.tsx
@@ -21,6 +21,8 @@ import {
   TimeSeriesPlot,
   SpectrumPlot,
   ExportPanel,
+  ProbesPanel,
+  SourcesPanel,
   Button,
   Badge,
   Slider,
@@ -31,6 +33,8 @@ import {
   useViewOptions,
   useGridInfo,
   useProbeData,
+  useProbeVisibility,
+  useSourceData,
   usePerformanceSettings,
   useExport,
 } from "@strata/ui";
@@ -202,6 +206,19 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
   const { shape, resolution } = useGridInfo();
   const { probeData } = useProbeData();
   const {
+    hiddenProbes,
+    showProbeMarkers,
+    toggleProbeVisibility,
+    showAllProbes,
+    hideAllProbes,
+    setShowProbeMarkers,
+  } = useProbeVisibility();
+  const {
+    sources,
+    showSourceMarkers,
+    setShowSourceMarkers,
+  } = useSourceData();
+  const {
     enableDownsampling,
     targetVoxels,
     downsampleMethod,
@@ -212,11 +229,19 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
   const [viewMode, setViewMode] = useState<"time" | "spectrum">("time");
   const [showMetadata, setShowMetadata] = useState(false);
 
-  // Derive selected probe from probe data
+  // Derive selected probe from probe data (first visible probe for spectrum)
   const probeNames = probeData ? Object.keys(probeData.probes) : [];
-  const [selectedProbeOverride, setSelectedProbeOverride] = useState<string | null>(null);
-  const selectedProbe = selectedProbeOverride ?? probeNames[0] ?? null;
-  const setSelectedProbe = (name: string | null) => setSelectedProbeOverride(name);
+  const visibleProbeNames = probeNames.filter(name => !hiddenProbes.includes(name));
+  const selectedProbe = visibleProbeNames[0] ?? null;
+
+  // Compute probes array for ProbesPanel and 3D markers
+  const probesForPanel = useMemo(() => {
+    if (!probeData) return [];
+    return Object.entries(probeData.probes).map(([name, probe]) => ({
+      name,
+      position: probe.position,
+    }));
+  }, [probeData]);
 
   // Renderer ref for export
   const rendererRef = useRef<VoxelRendererHandle>(null);
@@ -627,10 +652,13 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
               step={1}
               onValueChange={([v]) => setThreshold(v / 100)}
             />
-            <div className="flex justify-between text-xs text-muted-foreground">
-              <span>0%</span>
-              <span>{Math.round(threshold * 100)}%</span>
-              <span>100%</span>
+            <div className="relative h-4">
+              <span
+                className="absolute text-xs text-muted-foreground -translate-x-1/2"
+                style={{ left: `${threshold * 100}%` }}
+              >
+                {Math.round(threshold * 100)}%
+              </span>
             </div>
           </Panel>
 
@@ -643,10 +671,13 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
               step={1}
               onValueChange={([v]) => setDisplayFill(v / 100)}
             />
-            <div className="flex justify-between text-xs text-muted-foreground">
-              <span>1%</span>
-              <span>{Math.round(displayFill * 100)}%</span>
-              <span>100%</span>
+            <div className="relative h-4">
+              <span
+                className="absolute text-xs text-muted-foreground -translate-x-1/2"
+                style={{ left: `${((displayFill * 100) - 1) / 99 * 100}%` }}
+              >
+                {Math.round(displayFill * 100)}%
+              </span>
             </div>
           </Panel>
 
@@ -704,6 +735,28 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
                 Show Axes
               </label>
             </div>
+          </Panel>
+
+          {/* Probes */}
+          <Panel title="Probes">
+            <ProbesPanel
+              probes={probesForPanel}
+              hiddenProbes={hiddenProbes}
+              showProbeMarkers={showProbeMarkers}
+              onToggleProbe={toggleProbeVisibility}
+              onShowAll={showAllProbes}
+              onHideAll={hideAllProbes}
+              onToggleMarkers={setShowProbeMarkers}
+            />
+          </Panel>
+
+          {/* Sources */}
+          <Panel title="Sources">
+            <SourcesPanel
+              sources={sources}
+              showSourceMarkers={showSourceMarkers}
+              onToggleMarkers={setShowSourceMarkers}
+            />
           </Panel>
 
           {/* Performance */}
@@ -765,6 +818,11 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
           downsampleMethod={downsampleMethod}
           showPerformanceMetrics={showPerformanceMetrics}
           onPerformanceUpdate={updatePerformanceMetrics}
+          probes={probesForPanel}
+          hiddenProbes={hiddenProbes}
+          showProbeMarkers={showProbeMarkers}
+          sources={sources}
+          showSourceMarkers={showSourceMarkers}
         />
       }
       bottom={
@@ -775,13 +833,14 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
           playbackSpeed={playbackSpeed}
           probeData={probeData}
           selectedProbe={selectedProbe}
+          hiddenProbes={hiddenProbes}
           viewMode={viewMode}
           currentTime={currentTime}
+          sources={sources}
           onFrameChange={setCurrentFrame}
           onPlayingChange={handlePlayingChange}
           onTimeSelect={handleTimeSelect}
           onViewModeChange={setViewMode}
-          onSelectProbe={setSelectedProbe}
         />
       }
     />
@@ -898,13 +957,14 @@ interface BottomPanelProps {
   playbackSpeed: number;
   probeData: ReturnType<typeof useSimulationStore.getState>["probeData"];
   selectedProbe: string | null;
+  hiddenProbes: string[];
   viewMode: "time" | "spectrum";
   currentTime?: number;
+  sources: ReturnType<typeof useSourceData>["sources"];
   onFrameChange: (frame: number) => void;
   onPlayingChange: (playing: boolean) => void;
   onTimeSelect: (time: number) => void;
   onViewModeChange: (mode: "time" | "spectrum") => void;
-  onSelectProbe: (name: string | null) => void;
 }
 
 function BottomPanel({
@@ -914,20 +974,50 @@ function BottomPanel({
   playbackSpeed,
   probeData,
   selectedProbe,
+  hiddenProbes,
   viewMode,
   currentTime,
+  sources,
   onFrameChange,
   onPlayingChange,
   onTimeSelect,
   onViewModeChange,
-  onSelectProbe,
 }: BottomPanelProps) {
-  const probeNames = probeData ? Object.keys(probeData.probes) : [];
+  // Convert hiddenProbes array to Set for TimeSeriesPlot
+  const hiddenProbesSet = useMemo(() => new Set(hiddenProbes), [hiddenProbes]);
+
+  // Convert sources to SourceTimeSeries format for TimeSeriesPlot
+  const sourcesForPlot = useMemo(() => {
+    return sources
+      .filter(s => s.waveform !== undefined)
+      .map(s => ({
+        name: s.name,
+        type: s.type,
+        waveform: s.waveform!,
+      }));
+  }, [sources]);
+
+  // Spectrum mode state: 'spectrum' for power spectrum, 'transfer' for transfer function
+  const [spectrumMode, setSpectrumMode] = useState<"spectrum" | "transfer">("spectrum");
+
+  // Selected source for transfer function reference
+  const [selectedSourceIndex, setSelectedSourceIndex] = useState(0);
+
+  // Get available sources with waveforms
+  const sourcesWithWaveform = useMemo(() =>
+    sources.filter(s => s.waveform !== undefined),
+    [sources]
+  );
+
+  // Get selected source reference data
+  const referenceSource = sourcesWithWaveform[selectedSourceIndex];
+  const referenceData = referenceSource?.waveform;
+  const referenceName = referenceSource?.name;
 
   return (
     <div className="h-full flex flex-col">
       <div className="flex items-center justify-between mb-2">
-        <div className="flex gap-2">
+        <div className="flex items-center gap-2">
           <Button
             variant={viewMode === "time" ? "default" : "outline"}
             size="sm"
@@ -944,19 +1034,44 @@ function BottomPanel({
           >
             Spectrum
           </Button>
+          {viewMode === "spectrum" && selectedProbe && (
+            <span className="text-xs text-muted-foreground ml-2">
+              Showing: {selectedProbe}
+            </span>
+          )}
         </div>
-        {viewMode === "spectrum" && probeNames.length > 0 && (
-          <div className="flex gap-1">
-            {probeNames.map((name) => (
-              <Badge
-                key={name}
-                variant={selectedProbe === name ? "default" : "outline"}
-                className="cursor-pointer text-xs"
-                onClick={() => onSelectProbe(name)}
+        {/* Transfer function controls - show when in spectrum mode and sources available */}
+        {viewMode === "spectrum" && sourcesWithWaveform.length > 0 && (
+          <div className="flex items-center gap-2">
+            <Button
+              variant={spectrumMode === "spectrum" ? "default" : "outline"}
+              size="sm"
+              className="text-xs h-6"
+              onClick={() => setSpectrumMode("spectrum")}
+            >
+              Spectrum
+            </Button>
+            <Button
+              variant={spectrumMode === "transfer" ? "default" : "outline"}
+              size="sm"
+              className="text-xs h-6"
+              onClick={() => setSpectrumMode("transfer")}
+            >
+              Transfer Fn
+            </Button>
+            {spectrumMode === "transfer" && sourcesWithWaveform.length > 1 && (
+              <select
+                value={selectedSourceIndex}
+                onChange={(e) => setSelectedSourceIndex(Number(e.target.value))}
+                className="h-6 text-xs bg-secondary border rounded px-1"
               >
-                {name}
-              </Badge>
-            ))}
+                {sourcesWithWaveform.map((source, idx) => (
+                  <option key={source.name} value={idx}>
+                    {source.name}
+                  </option>
+                ))}
+              </select>
+            )}
           </div>
         )}
       </div>
@@ -972,15 +1087,28 @@ function BottomPanel({
             sampleRate={probeData.sampleRate}
             currentTime={currentTime}
             onTimeSelect={onTimeSelect}
+            hideProbeSelector
+            hiddenProbes={hiddenProbesSet}
+            sources={sourcesForPlot}
+            showSources={sourcesForPlot.length > 0}
           />
+        ) : !selectedProbe ? (
+          <div className="h-full bg-secondary/30 rounded-md flex items-center justify-center text-muted-foreground text-sm">
+            {Object.keys(probeData.probes).length === 0
+              ? "No probes in simulation"
+              : "No probes visible - enable a probe in the sidebar"}
+          </div>
         ) : (
           <SpectrumPlot
             data={
-              selectedProbe && probeData.probes[selectedProbe]
+              probeData.probes[selectedProbe]
                 ? probeData.probes[selectedProbe].data
                 : new Float32Array(0)
             }
             sampleRate={probeData.sampleRate}
+            mode={spectrumMode}
+            referenceData={referenceData}
+            referenceName={referenceName}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Add source waveform reading from HDF5 files
- Display source waveforms in Time Series plot with dashed yellow lines
- Implement Transfer Function mode H(f) = Y(f)/X(f) in Spectrum panel
- Add source selector for choosing reference source in transfer function computation

## Changes

### HDF5 Loader (`strata-ui/lib/loaders/hdf5.ts`)
- Extended `HDF5Source` interface to include optional `waveform` field
- Updated `readSources` to extract waveform data from HDF5 datasets

### Simulation Store (`strata-ui/stores/simulationStore.ts`)
- Added `waveform?: Float32Array` to `SourceData` type
- Added `showSourceMarkers` state and `setShowSourceMarkers` action
- Added `useSourceData` hook for accessing source state

### Time Series Plot (`strata-ui/components/visualization/TimeSeriesPlot.tsx`)
- Added `SourceTimeSeries` interface and `sources`/`showSources` props
- Render source waveforms as dashed yellow lines alongside probe traces
- Include source values in hover tooltip

### Spectrum Plot (`strata-ui/components/visualization/SpectrumPlot.tsx`)
- Added `SpectrumMode` type ('spectrum' | 'transfer')
- Added `mode`, `referenceData`, and `referenceName` props
- Compute transfer function H(f) = Y(f)/X(f) with proper dB scaling
- Display transfer function title and reference source badge

### New Components
- `ProbesPanel.tsx`: Sidebar panel for managing probe visibility
- `SourcesPanel.tsx`: Sidebar panel showing source information and 3D marker toggle

### ViewerPage Integration
- Added transfer function mode toggle buttons in bottom panel
- Added source selector dropdown when multiple sources available
- Connected source waveforms to TimeSeriesPlot and SpectrumPlot

## Test plan
- [ ] Load HDF5 file with source waveform data
- [ ] Verify source waveforms appear as dashed lines in Time Series plot
- [ ] Toggle between Spectrum and Transfer Function modes
- [ ] Verify transfer function shows proper dB scale (+/- values)
- [ ] Select different sources as reference (if multiple available)

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)