### PR TITLE
Add geometry overlay to 2D slice visualization

### DIFF
--- a/strata-ui/src/components/visualization/SliceControlPanel.tsx
+++ b/strata-ui/src/components/visualization/SliceControlPanel.tsx
@@ -24,6 +24,12 @@ export interface SliceControlPanelProps {
   onAxisChange: (axis: SliceAxis) => void;
   /** Callback when position changes */
   onPositionChange: (position: number) => void;
+  /** Whether geometry overlay is shown */
+  showGeometry?: boolean;
+  /** Callback when geometry visibility changes */
+  onShowGeometryChange?: (show: boolean) => void;
+  /** Whether geometry data is available */
+  hasGeometry?: boolean;
 }
 
 const AXIS_OPTIONS: { value: SliceAxis; label: string; description: string }[] = [
@@ -39,6 +45,9 @@ export function SliceControlPanel({
   resolution,
   onAxisChange,
   onPositionChange,
+  showGeometry = false,
+  onShowGeometryChange,
+  hasGeometry = false,
 }: SliceControlPanelProps) {
   // Memoize slider value to prevent infinite re-render loops
   const sliderValue = useMemo(() => [position * 100], [position]);
@@ -104,6 +113,19 @@ export function SliceControlPanel({
             <span>0 - {((axisSize - 1) * resolution * 100).toFixed(1)} cm</span>
           </div>
         </div>
+
+        {/* Geometry overlay toggle */}
+        {hasGeometry && onShowGeometryChange && (
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={showGeometry}
+              onChange={(e) => onShowGeometryChange(e.target.checked)}
+              className="rounded"
+            />
+            Show Geometry
+          </label>
+        )}
       </div>
     </Panel>
   );

--- a/strata-ui/src/lib/sliceUtils.ts
+++ b/strata-ui/src/lib/sliceUtils.ts
@@ -176,3 +176,103 @@ export function getSlicePlaneLabel(axis: SliceAxis): string {
       return "XY plane (Z slice)";
   }
 }
+
+/**
+ * Result of geometry slice extraction
+ */
+export interface GeometrySliceData {
+  /** 2D geometry mask for the slice (1=air, 0=solid) */
+  data: Uint8Array;
+  /** Width of the slice in cells */
+  width: number;
+  /** Height of the slice in cells */
+  height: number;
+}
+
+/**
+ * Extract a 2D slice from a 3D geometry mask.
+ *
+ * The 3D data is assumed to be in row-major order with the indexing:
+ * index = x + y * nx + z * nx * ny
+ *
+ * @param mask - 3D geometry mask as flat Uint8Array (1=air, 0=solid)
+ * @param shape - Grid dimensions [nx, ny, nz]
+ * @param axis - Axis perpendicular to the slice plane ('x', 'y', or 'z')
+ * @param normalizedPosition - Position along the axis (0-1)
+ * @returns GeometrySliceData containing the 2D slice
+ */
+export function extractGeometrySlice(
+  mask: Uint8Array,
+  shape: [number, number, number],
+  axis: SliceAxis,
+  normalizedPosition: number
+): GeometrySliceData {
+  const [nx, ny, nz] = shape;
+
+  // Clamp position to valid range
+  const clampedPosition = Math.max(0, Math.min(1, normalizedPosition));
+
+  if (axis === "z") {
+    // XY plane at constant Z (top-down view)
+    const zIndex = Math.min(
+      nz - 1,
+      Math.max(0, Math.round(clampedPosition * (nz - 1)))
+    );
+    const sliceData = new Uint8Array(nx * ny);
+
+    for (let y = 0; y < ny; y++) {
+      for (let x = 0; x < nx; x++) {
+        const idx3d = x + y * nx + zIndex * nx * ny;
+        sliceData[x + y * nx] = mask[idx3d];
+      }
+    }
+
+    return {
+      data: sliceData,
+      width: nx,
+      height: ny,
+    };
+  } else if (axis === "y") {
+    // XZ plane at constant Y (front/back view)
+    const yIndex = Math.min(
+      ny - 1,
+      Math.max(0, Math.round(clampedPosition * (ny - 1)))
+    );
+    const sliceData = new Uint8Array(nx * nz);
+
+    for (let z = 0; z < nz; z++) {
+      for (let x = 0; x < nx; x++) {
+        const idx3d = x + yIndex * nx + z * nx * ny;
+        // Store with Z as height (row), X as width (column)
+        sliceData[x + z * nx] = mask[idx3d];
+      }
+    }
+
+    return {
+      data: sliceData,
+      width: nx,
+      height: nz,
+    };
+  } else {
+    // YZ plane at constant X (left/right view)
+    const xIndex = Math.min(
+      nx - 1,
+      Math.max(0, Math.round(clampedPosition * (nx - 1)))
+    );
+    const sliceData = new Uint8Array(ny * nz);
+
+    for (let z = 0; z < nz; z++) {
+      for (let y = 0; y < ny; y++) {
+        const idx3d = xIndex + y * nx + z * nx * ny;
+        // Store with Z as height (row), Y as width (column)
+        sliceData[y + z * ny] = mask[idx3d];
+      }
+    }
+
+    return {
+      data: sliceData,
+      width: ny,
+      height: nz,
+    };
+  }
+}

--- a/strata-ui/src/stores/simulationStore.ts
+++ b/strata-ui/src/stores/simulationStore.ts
@@ -108,6 +108,7 @@ export interface SimulationState {
   viewMode: ViewMode;
   sliceAxis: SliceAxis;
   slicePosition: number; // 0-1 normalized position along axis
+  showSliceGeometry: boolean; // Whether to show geometry overlay on slice
 
   // Loading state
   isLoading: boolean;
@@ -172,6 +173,7 @@ export interface SimulationActions {
   setViewMode: (mode: ViewMode) => void;
   setSliceAxis: (axis: SliceAxis) => void;
   setSlicePosition: (position: number) => void;
+  setShowSliceGeometry: (show: boolean) => void;
 
   // Performance
   setEnableDownsampling: (enable: boolean) => void;
@@ -247,6 +249,7 @@ const DEFAULT_STATE: SimulationState = {
   viewMode: "3d",
   sliceAxis: "y",
   slicePosition: 0.5,
+  showSliceGeometry: true, // Show geometry overlay by default
 
   // Loading
   isLoading: false,
@@ -647,6 +650,8 @@ export const useSimulationStore = create<SimulationStore>()(
     setSlicePosition: (position: number) =>
       set({ slicePosition: Math.max(0, Math.min(1, position)) }),
 
+    setShowSliceGeometry: (show: boolean) => set({ showSliceGeometry: show }),
+
     // =========================================================================
     // Performance
     // =========================================================================
@@ -922,6 +927,7 @@ export const selectPerformanceMetrics = (state: SimulationStore) => state.perfor
 export const selectViewMode = (state: SimulationStore) => state.viewMode;
 export const selectSliceAxis = (state: SimulationStore) => state.sliceAxis;
 export const selectSlicePosition = (state: SimulationStore) => state.slicePosition;
+export const selectShowSliceGeometry = (state: SimulationStore) => state.showSliceGeometry;
 
 /** @deprecated Use individual selectors with useSimulationStore instead */
 export const usePlaybackState = () =>

--- a/strata-web/src/pages/ViewerPage.tsx
+++ b/strata-web/src/pages/ViewerPage.tsx
@@ -216,9 +216,14 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
   const mainViewMode = useSimulationStore((s) => s.viewMode);
   const sliceAxis = useSimulationStore((s) => s.sliceAxis);
   const slicePosition = useSimulationStore((s) => s.slicePosition);
+  const showSliceGeometry = useSimulationStore((s) => s.showSliceGeometry);
   const setMainViewMode = useSimulationStore((s) => s.setViewMode);
   const setSliceAxis = useSimulationStore((s) => s.setSliceAxis);
   const setSlicePosition = useSimulationStore((s) => s.setSlicePosition);
+  const setShowSliceGeometry = useSimulationStore((s) => s.setShowSliceGeometry);
+
+  // Geometry data
+  const geometry = useSimulationStore((s) => s.geometry);
 
   // Local state
   const [bottomViewMode, setBottomViewMode] = useState<"time" | "spectrum">("time");
@@ -600,6 +605,9 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
               resolution={resolution}
               onAxisChange={setSliceAxis}
               onPositionChange={setSlicePosition}
+              showGeometry={showSliceGeometry}
+              onShowGeometryChange={setShowSliceGeometry}
+              hasGeometry={!!geometry?.mask}
             />
           )}
 
@@ -793,6 +801,8 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
             resolution={resolution}
             axis={sliceAxis}
             position={slicePosition}
+            geometry={geometry?.mask}
+            showGeometry={showSliceGeometry}
           />
         ) : (
           <OptimizedVoxelRenderer


### PR DESCRIPTION
## Summary

- Adds geometry overlay rendering to 2D slice visualization
- Solid regions (walls, obstacles, enclosures) shown as semi-transparent dark gray
- Toggle in SliceControlPanel to show/hide geometry overlay
- Overlay enabled by default when geometry data is available

## Changes

### New Utilities
- `extractGeometrySlice()` in sliceUtils.ts - Extracts 2D geometry mask from 3D data

### SliceRenderer Updates
- Added `geometry` and `showGeometry` props
- Renders geometry overlay using Canvas 2D compositing
- Solid regions (mask=0) rendered as semi-transparent gray (#4a4a4a, alpha=180)

### SliceControlPanel Updates
- Added "Show Geometry" checkbox (visible when geometry data available)
- Props: `showGeometry`, `onShowGeometryChange`, `hasGeometry`

### Store Updates
- Added `showSliceGeometry` state (defaults to true)
- Added `setShowSliceGeometry` action
- Added `selectShowSliceGeometry` selector

### ViewerPage Integration
- Passes geometry mask and showGeometry state to SliceRenderer
- Passes toggle props to SliceControlPanel

## Test plan

- [ ] Load a simulation with geometry data (e.g., sealed subwoofer)
- [ ] Switch to Slice view mode
- [ ] Verify geometry overlay is visible by default
- [ ] Toggle "Show Geometry" checkbox and verify overlay toggles
- [ ] Change slice axis and position - verify geometry updates correctly
- [ ] Export slice image - verify geometry is included in export

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)