### PR TITLE
Add keyboard shortcuts for slice navigation

### DIFF
--- a/strata-ui/src/hooks/useSliceKeyboardNavigation.ts
+++ b/strata-ui/src/hooks/useSliceKeyboardNavigation.ts
@@ -1,0 +1,145 @@
+/**
+ * Hook for keyboard navigation in slice view mode.
+ *
+ * Provides keyboard shortcuts for:
+ * - Arrow keys: Move slice position
+ * - Number/letter keys: Switch axis
+ * - Home/End: Jump to start/end
+ */
+
+import { useEffect, useCallback } from "react";
+import type { SliceAxis } from "../stores/simulationStore";
+import { getAxisSize } from "../lib/sliceUtils";
+
+export interface SliceKeyboardCallbacks {
+  /** Called when position should change (normalized 0-1) */
+  onPositionChange: (position: number) => void;
+  /** Called when axis should change */
+  onAxisChange: (axis: SliceAxis) => void;
+}
+
+export interface UseSliceKeyboardNavigationOptions {
+  /** Whether keyboard navigation is enabled (typically viewMode === "slice") */
+  enabled: boolean;
+  /** Current slice position (normalized 0-1) */
+  position: number;
+  /** Current slice axis */
+  axis: SliceAxis;
+  /** Grid dimensions [nx, ny, nz] */
+  shape: [number, number, number];
+  /** Callbacks for state changes */
+  callbacks: SliceKeyboardCallbacks;
+}
+
+/**
+ * Hook to handle keyboard navigation for slice view.
+ *
+ * Shortcuts:
+ * - ↑/↓: Move slice position by 1 step
+ * - Shift + ↑/↓: Move slice position by 10 steps
+ * - 1/X: Switch to X axis (YZ plane)
+ * - 2/Y: Switch to Y axis (XZ plane)
+ * - 3/Z: Switch to Z axis (XY plane)
+ * - Home: Jump to position 0%
+ * - End: Jump to position 100%
+ */
+export function useSliceKeyboardNavigation({
+  enabled,
+  position,
+  axis,
+  shape,
+  callbacks,
+}: UseSliceKeyboardNavigationOptions): void {
+  const { onPositionChange, onAxisChange } = callbacks;
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (!enabled) return;
+
+      // Don't handle if user is typing in an input
+      const target = event.target as HTMLElement;
+      if (
+        target.tagName === "INPUT" ||
+        target.tagName === "TEXTAREA" ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      const axisSize = getAxisSize(shape, axis);
+      // Calculate step size as normalized value (1 cell / total cells)
+      const singleStep = 1 / (axisSize - 1);
+      const largeStep = singleStep * 10;
+
+      switch (event.key) {
+        case "ArrowUp":
+        case "ArrowRight": {
+          event.preventDefault();
+          const step = event.shiftKey ? largeStep : singleStep;
+          const newPosition = Math.min(1, position + step);
+          onPositionChange(newPosition);
+          break;
+        }
+
+        case "ArrowDown":
+        case "ArrowLeft": {
+          event.preventDefault();
+          const step = event.shiftKey ? largeStep : singleStep;
+          const newPosition = Math.max(0, position - step);
+          onPositionChange(newPosition);
+          break;
+        }
+
+        case "Home": {
+          event.preventDefault();
+          onPositionChange(0);
+          break;
+        }
+
+        case "End": {
+          event.preventDefault();
+          onPositionChange(1);
+          break;
+        }
+
+        case "1":
+        case "x":
+        case "X": {
+          // Don't switch if modifier keys are pressed (except shift for X)
+          if (event.ctrlKey || event.metaKey || event.altKey) return;
+          event.preventDefault();
+          onAxisChange("x");
+          break;
+        }
+
+        case "2":
+        case "y":
+        case "Y": {
+          if (event.ctrlKey || event.metaKey || event.altKey) return;
+          event.preventDefault();
+          onAxisChange("y");
+          break;
+        }
+
+        case "3":
+        case "z":
+        case "Z": {
+          if (event.ctrlKey || event.metaKey || event.altKey) return;
+          event.preventDefault();
+          onAxisChange("z");
+          break;
+        }
+      }
+    },
+    [enabled, position, axis, shape, onPositionChange, onAxisChange]
+  );
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [enabled, handleKeyDown]);
+}

--- a/strata-ui/src/index.ts
+++ b/strata-ui/src/index.ts
@@ -87,6 +87,7 @@ export { useProbeData as useProbeDataLoader } from './hooks/useProbeData'
 export { useSimulation } from './hooks/useSimulation'
 export { useStreamingBuffer } from './hooks/useStreamingBuffer'
 export { useUrlState } from './hooks/useUrlState'
+export { useSliceKeyboardNavigation, type SliceKeyboardCallbacks, type UseSliceKeyboardNavigationOptions } from './hooks/useSliceKeyboardNavigation'
 // useVideoExport moved to strata-web (requires @ffmpeg)
 
 // =============================================================================

--- a/strata-web/src/pages/ViewerPage.tsx
+++ b/strata-web/src/pages/ViewerPage.tsx
@@ -36,6 +36,7 @@ import {
   useProbeData,
   usePerformanceSettings,
   useExport,
+  useSliceKeyboardNavigation,
 } from "@strata/ui";
 import type {
   VoxelRendererHandle,
@@ -219,6 +220,18 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
   const setMainViewMode = useSimulationStore((s) => s.setViewMode);
   const setSliceAxis = useSimulationStore((s) => s.setSliceAxis);
   const setSlicePosition = useSimulationStore((s) => s.setSlicePosition);
+
+  // Slice keyboard navigation
+  useSliceKeyboardNavigation({
+    enabled: mainViewMode === "slice" && isLoaded,
+    position: slicePosition,
+    axis: sliceAxis,
+    shape,
+    callbacks: {
+      onPositionChange: setSlicePosition,
+      onAxisChange: setSliceAxis,
+    },
+  });
 
   // Local state
   const [bottomViewMode, setBottomViewMode] = useState<"time" | "spectrum">("time");


### PR DESCRIPTION
## Summary

- Add `useSliceKeyboardNavigation` hook for keyboard navigation in slice view mode
- Integrate hook into ViewerPage for seamless slice exploration
- Support arrow keys, number/letter keys, and Home/End for position control

## Keyboard Shortcuts

| Key | Action |
|-----|--------|
| `↑` / `↓` / `←` / `→` | Move slice position by 1 step |
| `Shift + Arrow` | Move slice position by 10 steps |
| `1` / `X` | Switch to X axis (YZ plane) |
| `2` / `Y` | Switch to Y axis (XZ plane) |
| `3` / `Z` | Switch to Z axis (XY plane) |
| `Home` | Jump to position 0% |
| `End` | Jump to position 100% |

## Test plan

- [ ] Switch to slice view mode in the viewer
- [ ] Verify arrow keys move slice position by single steps
- [ ] Verify Shift+arrow keys move by 10 steps
- [ ] Verify number keys (1/2/3) switch axis
- [ ] Verify letter keys (X/Y/Z) switch axis
- [ ] Verify Home jumps to 0%, End jumps to 100%
- [ ] Verify shortcuts don't work in 3D view mode
- [ ] Verify shortcuts don't interfere with input fields

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)