### PR TITLE
Add coherence function analysis to spectral viewer

### DIFF
--- a/strata-ui/src/index.ts
+++ b/strata-ui/src/index.ts
@@ -65,6 +65,7 @@ export { ViewerHelpModal } from './components/visualization/ViewerHelpModal'
 export { BuilderHelpModal } from './components/visualization/BuilderHelpModal'
 export { Spectrogram } from './components/visualization/Spectrogram'
 export { SpectrumPlot } from './components/visualization/SpectrumPlot'
+export type { SpectrumPlotProps, FrequencyMarker, AnalysisMode, ProbeRecord } from './components/visualization/SpectrumPlot'
 export { ThreeViewer } from './components/visualization/ThreeViewer'
 export { TimeSeriesPlot } from './components/visualization/TimeSeriesPlot'
 // VideoExportButton moved to strata-web (requires useVideoExport/FFmpeg)
@@ -142,6 +143,10 @@ export {
   nextPowerOf2,
   terminateFFTWorker,
   hasWorkerSupport as fftHasWorkerSupport,
+  // Coherence analysis
+  computeCoherence,
+  transferMagnitudeToDb,
+  type CoherenceResult,
 } from './lib/fft'
 
 // Export utilities


### PR DESCRIPTION
## Summary

- Implements coherence function analysis for comparing signals between probes
- Adds Welch's method for cross-spectral density computation
- Provides interactive visualization with transfer function overlay

## Changes

### Core Computation (`fft.ts`)
- `computeCoherence()` - Welch's method with 50% overlap and Hanning window
- `CoherenceResult` interface - frequencies, coherence γ², transfer function H(f)
- `transferMagnitudeToDb()` - utility for dB conversion

### UI Components
- Adds "Coherence" mode toggle in bottom panel alongside Time Series/Spectrum
- Dual-probe selection: reference (input) and measurement (output)
- Coherence display with 0-1 scale and 50% threshold indicator
- Transfer function magnitude overlay on secondary Y-axis

### Visualization
- Interactive tooltip showing γ²(f), H(f) in dB, and frequency
- Brush-to-zoom with double-click reset (same as spectrum mode)
- Legend showing coherence and transfer function lines

## Test plan

- [ ] Load simulation with 2+ probes
- [ ] Click "Coherence" button in bottom panel
- [ ] Select different reference and measurement probes
- [ ] Verify coherence displays on 0-1 scale
- [ ] Check tooltip displays γ² and H(f) values on hover
- [ ] Test brush-to-zoom and double-click reset
- [ ] Verify single-probe simulations disable Coherence button

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)