### PR TITLE
Add slice animation export for 2D slice movies

### DIFF
--- a/strata-web/src/pages/ViewerPage.tsx
+++ b/strata-web/src/pages/ViewerPage.tsx
@@ -844,6 +844,10 @@ export default function ViewerPage({ onBack }: ViewerPageProps) {
               resolution={resolution}
               probeData={probeData}
               getViewState={getViewState}
+              isSliceMode={mainViewMode === "slice"}
+              sliceAxis={sliceAxis}
+              slicePosition={slicePosition}
+              setSlicePosition={setSlicePosition}
             />
           </Panel>
 


### PR DESCRIPTION
## Summary

- Adds dedicated export options for 2D slice visualization when in slice view mode
- Time Animation: Export time-based animation at fixed slice position
- Position Sweep: Export animation sweeping through slice positions at fixed timestep
- Format support: PNG sequence (ZIP) and GIF with configurable FPS

## Test plan

- [ ] Switch to slice view mode and verify "Slice Animation" section appears in Export panel
- [ ] Test Time Animation export with PNG sequence format
- [ ] Test Time Animation export with GIF format
- [ ] Test Position Sweep export with PNG sequence format
- [ ] Test Position Sweep export with GIF format
- [ ] Verify colorbar is included in exports
- [ ] Verify geometry overlay is included when enabled
- [ ] Verify slice position is restored after position sweep export

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)