### PR TITLE
Add Web Worker support for impulse response computation

### DIFF
--- a/strata-ui/src/index.ts
+++ b/strata-ui/src/index.ts
@@ -171,6 +171,10 @@ export {
   computeCentreTime,
   computeAcousticMetrics,
   analyzeTransferFunction,
+  // Async Web Worker support
+  analyzeTransferFunctionAsync,
+  hasAcousticsWorkerSupport,
+  terminateAcousticsWorker,
   type ImpulseResponseResult,
   type EnergyDecayResult,
   type AcousticMetrics,

--- a/strata-ui/src/workers/acoustics.worker.ts
+++ b/strata-ui/src/workers/acoustics.worker.ts
@@ -1,0 +1,90 @@
+/**
+ * Web Worker for acoustic analysis computation.
+ *
+ * Offloads computationally intensive impulse response and acoustic metrics
+ * analysis to a background thread to keep the main thread responsive.
+ */
+
+import {
+  analyzeTransferFunction,
+  type ImpulseResponseResult,
+  type EnergyDecayResult,
+  type AcousticMetrics,
+  type WindowType,
+} from "@/lib/acoustics";
+
+// =============================================================================
+// Message Types
+// =============================================================================
+
+export interface AcousticsWorkerRequest {
+  type: "analyzeTransferFunction";
+  id: number;
+  transferReal: Float32Array;
+  transferImag: Float32Array;
+  sampleRate: number;
+  windowType: WindowType;
+}
+
+export interface AcousticsWorkerResponse {
+  type: "analyzeTransferFunction";
+  id: number;
+  impulseResponse: ImpulseResponseResult;
+  energyDecay: EnergyDecayResult;
+  metrics: AcousticMetrics;
+}
+
+export interface AcousticsWorkerError {
+  type: "error";
+  id: number;
+  error: string;
+}
+
+export type AcousticsWorkerMessage = AcousticsWorkerResponse | AcousticsWorkerError;
+
+// =============================================================================
+// Worker Logic
+// =============================================================================
+
+self.onmessage = (event: MessageEvent<AcousticsWorkerRequest>) => {
+  const request = event.data;
+
+  try {
+    switch (request.type) {
+      case "analyzeTransferFunction": {
+        const result = analyzeTransferFunction(
+          request.transferReal,
+          request.transferImag,
+          request.sampleRate,
+          request.windowType
+        );
+
+        const response: AcousticsWorkerResponse = {
+          type: "analyzeTransferFunction",
+          id: request.id,
+          impulseResponse: result.impulseResponse,
+          energyDecay: result.energyDecay,
+          metrics: result.metrics,
+        };
+
+        // Transfer ownership of buffers for zero-copy
+        self.postMessage(response, {
+          transfer: [
+            result.impulseResponse.impulseResponse.buffer,
+            result.impulseResponse.timeAxis.buffer,
+            result.energyDecay.decayCurve.buffer,
+            result.energyDecay.timeAxis.buffer,
+          ],
+        });
+        break;
+      }
+    }
+  } catch (error) {
+    const errorResponse: AcousticsWorkerError = {
+      type: "error",
+      id: request.id,
+      error: error instanceof Error ? error.message : "Unknown error",
+    };
+    self.postMessage(errorResponse);
+  }
+};


### PR DESCRIPTION
## Summary
- Add `acoustics.worker.ts` for background thread computation of impulse response and acoustic metrics
- Add `analyzeTransferFunctionAsync` wrapper with automatic sync fallback when workers unavailable
- Update `ImpulseResponseView` component to use async computation with proper cancellation handling
- Use transferable objects for zero-copy data transfer between main thread and worker

## Test plan
- [x] New async tests pass (`analyzeTransferFunctionAsync`, `hasAcousticsWorkerSupport`, `terminateAcousticsWorker`)
- [x] Existing acoustic analysis tests still pass (28 tests)
- [x] Build completes successfully with new worker bundle
- [ ] Manual testing: Load spectral viewer with impulse response tab, verify UI remains responsive during analysis

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)