### PR TITLE
Fix voxelGeometry default value test expectations

### DIFF
--- a/strata-ui/src/hooks/__tests__/useUrlState.test.tsx
+++ b/strata-ui/src/hooks/__tests__/useUrlState.test.tsx
@@ -123,7 +123,7 @@ describe("useUrlState", () => {
       renderHook(() => useUrlState(), { wrapper });
 
       const state = useSimulationStore.getState();
-      expect(state.voxelGeometry).toBe("point"); // Default
+      expect(state.voxelGeometry).toBe("hidden"); // Default
     });
   });
 

--- a/strata-ui/src/stores/__tests__/simulationStore.test.ts
+++ b/strata-ui/src/stores/__tests__/simulationStore.test.ts
@@ -28,7 +28,7 @@ describe("SimulationStore", () => {
 
       expect(state.colormap).toBe("diverging");
       expect(state.pressureRange).toBe("auto");
-      expect(state.voxelGeometry).toBe("point");
+      expect(state.voxelGeometry).toBe("hidden");
       expect(state.showWireframe).toBe(false);
       expect(state.boundaryOpacity).toBe(30);
       expect(state.threshold).toBe(0);


### PR DESCRIPTION
## Summary

Update test expectations to match the actual default value for `voxelGeometry` in the simulation store.

## Changes

- Updated `simulationStore.test.ts` to expect `"hidden"` as the default voxelGeometry
- Updated `useUrlState.test.tsx` to expect `"hidden"` as the fallback for invalid geometry

## Root Cause

The default value for `voxelGeometry` in `simulationStore.ts` (line 272) is `"hidden"`, but the test expectations still expected `"point"`. This likely occurred when the default was intentionally changed but the tests weren't updated.

## Test Plan

- [x] Run `pnpm exec vitest run src/stores/__tests__/simulationStore.test.ts` - 30 tests pass
- [x] Run `pnpm exec vitest run src/hooks/__tests__/useUrlState.test.tsx` - 16 tests pass
- [x] Build succeeds with `pnpm build`
- [x] Type check passes with `pnpm type-check`

Closes #102